### PR TITLE
ND Wind and TAS Display fixed

### DIFF
--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.html
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.html
@@ -26,7 +26,7 @@
                     <div id="Speed">
                         <svg>
                             <text id="GS_Text" class="Small" x="0%" y="20%" alignment-baseline="baseline">GS</text>
-                            <text id="GS_Value" class="Value" x="10%" y="20%" alignment-baseline="baseline">---</text>
+                            <text id="GS_Value" class="Value" x="24%" y="20%" alignment-baseline="baseline" text-anchor="end">---</text>
                             <text id="TAS_Text" class="Small" x="26%" y="20%" alignment-baseline="baseline">TAS</text>
                             <text id="TAS_Value" class="Value" x="39%" y="20%" alignment-baseline="baseline">---</text>
                             <text id="Wind_Direction" class="Value" x="0%" y="45%" alignment-baseline="baseline">--</text>

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.js
@@ -443,6 +443,40 @@ class B747_8_MFD_NDInfo extends NavSystemElement {
         if (this.ndInfo != null) {
             this.ndInfo.update(_deltaTime);
         }
+
+        var IRSState = SimVar.GetSimVarValue("L:SALTY_IRS_STATE", "Enum");
+        var showData; 
+        var groundSpeed = Math.round(Simplane.getGroundSpeed());
+        var gs = this.ndInfo.querySelector("#GS_Value");
+        const tas_text = this.ndInfo.querySelector("#TAS_Text");
+        var tas_val = this.ndInfo.querySelector("#TAS_Value");
+
+        var wd = this.ndInfo.querySelector("#Wind_Direction");
+        var ws = this.ndInfo.querySelector("#Wind_Strength");
+        var wa = this.ndInfo.querySelector("#Wind_Arrow");
+        const sep = this.ndInfo.querySelector("#Wind_Separator");
+
+        if(IRSState != 2 || groundSpeed < 100) {
+            showData = false; 
+       }
+       else {
+           showData = true;
+       }
+
+       tas_text.setAttribute("visibility", (showData) ? "visible" : "hidden");
+       tas_val.setAttribute("visibility", (showData) ? "visible" : "hidden");
+
+       sep.setAttribute("visibility", (showData) ? "visible" : "hidden");
+       wd.setAttribute("visibility", (showData) ? "visible" : "hidden");
+       ws.setAttribute("visibility", (showData) ? "visible" : "hidden");
+       wa.setAttribute("visibility", (showData) ? "visible" : "hidden");
+
+       if(IRSState != 2) {
+           gs.textContent = "---";
+       }
+       else {
+           gs.textContent = groundSpeed.toString().padStart(3); 
+       }
     }
     onExit() {
     }

--- a/layout.json
+++ b/layout.json
@@ -3,197 +3,197 @@
         {
             "path": "html_ui/Pages/Salty/SaltyBase.js",
             "size": 182,
-            "date": 132453436207349992
+            "date": 132453625764569402
         },
         {
             "path": "html_ui/Pages/Salty/SaltyIRS.js",
             "size": 1607,
-            "date": 132453436207360000
+            "date": 132453625764569402
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.html",
             "size": 4048,
-            "date": 132453147645271752
+            "date": 132453625764589348
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.js",
             "size": 4087,
-            "date": 132453147645271752
+            "date": 132453625764589348
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.css",
             "size": 1102,
-            "date": 132453147645281758
+            "date": 132453625764599320
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.html",
             "size": 4352,
-            "date": 132453147645281758
+            "date": 132453625764609296
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.js",
             "size": 2526,
-            "date": 132453147645291768
+            "date": 132453625764609296
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_FCTL.css",
             "size": 1085,
-            "date": 132453147645291768
+            "date": 132453625764609296
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_FCTL.html",
             "size": 11319,
-            "date": 132453147645301776
+            "date": 132453625764792318
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_FCTL.js",
             "size": 8580,
-            "date": 132453147645301776
+            "date": 132453625764802292
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Stat.css",
             "size": 1026,
-            "date": 132453147645301776
+            "date": 132453625764802292
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Stat.html",
             "size": 3122,
-            "date": 132453147645311788
+            "date": 132453625764812276
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Stat.js",
             "size": 2177,
-            "date": 132453147645311788
+            "date": 132453625764812276
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC.html",
             "size": 4961,
-            "date": 132453521581562166
+            "date": 132453625764822240
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js",
             "size": 35668,
-            "date": 132453436207370012
+            "date": 132453625764832208
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplayPages.js",
             "size": 1801,
-            "date": 132453521581572246
+            "date": 132453625764832208
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_SaltyOptions.js",
             "size": 1274,
-            "date": 132453521581582184
+            "date": 132453625764842182
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.html",
-            "size": 10418,
-            "date": 132453436207380018
+            "size": 10436,
+            "date": 132453718566662024
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.js",
-            "size": 18568,
-            "date": 132453436207390030
+            "size": 19955,
+            "date": 132453717380414354
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/Salty_BaseNDCompass.js",
             "size": 36530,
-            "date": 132453436207400040
+            "date": 132453625764862134
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/Salty_NDCompass.js",
             "size": 48469,
-            "date": 132453436207410048
+            "date": 132453625765051622
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.css",
             "size": 3504,
-            "date": 132453147645321792
+            "date": 132453625765061598
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.html",
             "size": 6072,
-            "date": 132453436207410048
+            "date": 132453625765061598
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.js",
             "size": 8883,
-            "date": 132453436207420056
+            "date": 132453625765071558
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.css",
             "size": 3451,
-            "date": 132453147645331802
+            "date": 132453625765071558
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.html",
             "size": 1191,
-            "date": 132453147645331802
+            "date": 132453625765071558
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js",
             "size": 18909,
-            "date": 132453568133476756
+            "date": 132453625765081544
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/approach.FLT",
             "size": 5193,
-            "date": 132453436207309956
+            "date": 132453625764256776
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/apron.FLT",
             "size": 5059,
-            "date": 132453436207319966
+            "date": 132453625764256776
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/Climb.flt",
             "size": 5198,
-            "date": 132453436207309956
+            "date": 132453625764246804
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/cruise.FLT",
             "size": 5193,
-            "date": 132453436207329974
+            "date": 132453625764266748
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/engines.cfg",
             "size": 7130,
-            "date": 132453147645211694
+            "date": 132453625764266748
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/final.FLT",
             "size": 5201,
-            "date": 132453436207329974
+            "date": 132453625764266748
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/flight_model.cfg",
             "size": 41126,
-            "date": 132453147645221704
+            "date": 132453625764437266
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/hangar.flt",
             "size": 4172,
-            "date": 132453436207329974
+            "date": 132453625764447298
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/runway.FLT",
             "size": 5058,
-            "date": 132453436207339982
+            "date": 132453625764529488
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/taxi.FLT",
             "size": 4987,
-            "date": 132453436207339982
+            "date": 132453625764539496
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/model/747_8I_INTERIOR.xml",
             "size": 184111,
-            "date": 132453147645231712
+            "date": 132453625764529488
         },
         {
             "path": "ModelBehaviorDefs/Asobo/Airliner/Boeing.xml",
             "size": 45456,
-            "date": 132453147645201690
+            "date": 132453625764226856
         }
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -17,5 +17,5 @@
             "OlderHistory": ""
         }
     },
-    "total_package_size": "00000000000000562796"
+    "total_package_size": "00000000000000564201"
 }


### PR DESCRIPTION
Resolves #27 

**Summary of changes** 
Now, the ND will show GS --- if the IRS is not aligned. 
Below 100 kts with aligned IRS, GS value will be indicated. 
TAS value, wind arrow, wind separator "/", wind speed and direction will be shown as long as the GS > 100 kts. 
GS value alignment changed slightly to the right for double/single digit GS values. 
 
