### PR TITLE
ND Waypoint displayed after IRS alignment

### DIFF
--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.html
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.html
@@ -48,11 +48,13 @@
 
                     <div id="Waypoint">
                         <svg>
+                            <g id="Waypoint_Data">
                             <text id="WP_Name" class="Large" x="75%" y="20%" alignment-baseline="baseline"></text>
                             <text id="WP_Track_Value" class="Value" x="100%" y="20%" alignment-baseline="baseline">---&deg</text>
                             <text id="WP_Distance_Value" class="Value" x="92%" y="45%" alignment-baseline="baseline">-.-</text>
                             <text id="WP_Distance_Units" class="Units" x="100%" y="45%" alignment-baseline="baseline">NM</text>
                             <text id="WP_Time" class="Value" x="100%" y="70%" alignment-baseline="baseline">--:--</text>
+                            </g>
                         </svg>
                     </div>
                 </div>

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.js
@@ -468,6 +468,9 @@ class B747_8_MFD_NDInfo extends NavSystemElement {
         var wa = this.ndInfo.querySelector("#Wind_Arrow");
         const sep = this.ndInfo.querySelector("#Wind_Separator");
 
+        //contains waypoint name, track, dist
+        var wpdata = this.ndInfo.querySelector("#Waypoint_Data");
+
         if(IRSState != 2 || groundSpeed < 100) {
             showData = false; 
        }
@@ -485,9 +488,11 @@ class B747_8_MFD_NDInfo extends NavSystemElement {
 
        if(IRSState != 2) {
            gs.textContent = "---";
+           wpdata.setAttribute("visiblity", "hidden");
        }
        else {
            gs.textContent = groundSpeed.toString().padStart(3); 
+           wpdata.setAttribute("visibility", "visible"); 
        }
     }
     onExit() {

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.js
@@ -488,7 +488,7 @@ class B747_8_MFD_NDInfo extends NavSystemElement {
 
        if(IRSState != 2) {
            gs.textContent = "---";
-           wpdata.setAttribute("visiblity", "hidden");
+           wpdata.setAttribute("visibility", "hidden");
        }
        else {
            gs.textContent = groundSpeed.toString().padStart(3); 

--- a/layout.json
+++ b/layout.json
@@ -3,227 +3,227 @@
         {
             "path": "html_ui/Pages/Salty/SaltyBase.js",
             "size": 182,
-            "date": 132453436207349992
+            "date": 132453625764569402
         },
         {
             "path": "html_ui/Pages/Salty/SaltyIRS.js",
             "size": 1607,
-            "date": 132453436207360000
+            "date": 132453625764569402
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.html",
             "size": 4277,
-            "date": 132454083080228346
+            "date": 132455062165908136
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.js",
             "size": 4175,
-            "date": 132454083080258372
+            "date": 132455062165917776
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.css",
             "size": 1102,
-            "date": 132453147645281758
+            "date": 132453625764599320
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.html",
             "size": 4352,
-            "date": 132453147645281758
+            "date": 132453625764609296
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.js",
             "size": 2526,
-            "date": 132453147645291768
+            "date": 132453625764609296
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_ELEC.css",
             "size": 1883,
-            "date": 132454083080268380
+            "date": 132455062165927758
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_ELEC.html",
             "size": 14074,
-            "date": 132454083080278390
+            "date": 132455062165937722
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_ELEC.js",
             "size": 22325,
-            "date": 132454083080278390
+            "date": 132455062165937722
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_FCTL.css",
             "size": 1085,
-            "date": 132453147645291768
+            "date": 132453625764609296
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_FCTL.html",
             "size": 11319,
-            "date": 132453147645301776
+            "date": 132453625764792318
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_FCTL.js",
             "size": 8580,
-            "date": 132453147645301776
+            "date": 132453625764802292
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Stat.css",
             "size": 1026,
-            "date": 132453147645301776
+            "date": 132453625764802292
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Stat.html",
             "size": 3122,
-            "date": 132453147645311788
+            "date": 132453625764812276
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Stat.js",
             "size": 2177,
-            "date": 132453147645311788
+            "date": 132453625764812276
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC.html",
             "size": 4961,
-            "date": 132453521581562166
+            "date": 132453625764822240
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js",
             "size": 35967,
-            "date": 132455100561712710
+            "date": 132456245139865110
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplayPages.js",
             "size": 1801,
-            "date": 132453521581572246
+            "date": 132453625764832208
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_SaltyOptions.js",
             "size": 1274,
-            "date": 132453521581582184
+            "date": 132453625764842182
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_TakeOffPage.js",
             "size": 5797,
-            "date": 132454127895850070
+            "date": 132456245139874764
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.html",
-            "size": 10436,
-            "date": 132455133446368690
+            "size": 11771,
+            "date": 132456516588017126
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.js",
-            "size": 19955,
-            "date": 132455133446378704
+            "size": 20901,
+            "date": 132456517543755478
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/Salty_BaseNDCompass.js",
             "size": 36530,
-            "date": 132453436207400040
+            "date": 132453625764862134
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/Salty_NDCompass.js",
             "size": 48727,
-            "date": 132455233584055452
+            "date": 132455871932021850
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/AirspeedIndicator.js",
             "size": 64181,
-            "date": 132455060648234470
+            "date": 132456516300904786
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/AttitudeIndicator.js",
-            "size": 41319,
-            "date": 132455977887134246
+            "size": 41588,
+            "date": 132456245139904658
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.css",
             "size": 3504,
-            "date": 132453147645321792
+            "date": 132453625765061598
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.html",
             "size": 6117,
-            "date": 132455305007164574
+            "date": 132456245139914662
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.js",
             "size": 8895,
-            "date": 132455976669718788
+            "date": 132456245140174016
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.css",
             "size": 3451,
-            "date": 132453147645331802
+            "date": 132453625765071558
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.html",
             "size": 1191,
-            "date": 132453147645331802
+            "date": 132453625765071558
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js",
             "size": 19125,
-            "date": 132455369864111604
+            "date": 132456245140183990
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/approach.FLT",
             "size": 5193,
-            "date": 132453436207309956
+            "date": 132453625764256776
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/apron.FLT",
             "size": 5059,
-            "date": 132453436207319966
+            "date": 132453625764256776
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/Climb.flt",
             "size": 5198,
-            "date": 132453436207309956
+            "date": 132453625764246804
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/cruise.FLT",
             "size": 5193,
-            "date": 132453436207329974
+            "date": 132453625764266748
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/engines.cfg",
             "size": 7130,
-            "date": 132453147645211694
+            "date": 132453625764266748
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/final.FLT",
             "size": 5201,
-            "date": 132453436207329974
+            "date": 132453625764266748
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/flight_model.cfg",
             "size": 41126,
-            "date": 132453147645221704
+            "date": 132453625764437266
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/hangar.flt",
             "size": 4172,
-            "date": 132453436207329974
+            "date": 132453625764447298
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/runway.FLT",
             "size": 5058,
-            "date": 132453436207339982
+            "date": 132453625764529488
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/taxi.FLT",
             "size": 4987,
-            "date": 132453436207339982
+            "date": 132453625764539496
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/model/747_8I_INTERIOR.xml",
             "size": 184111,
-            "date": 132453147645231712
+            "date": 132453625764529488
         },
         {
             "path": "ModelBehaviorDefs/Asobo/Airliner/Boeing.xml",
             "size": 45456,
-            "date": 132453147645201690
+            "date": 132453625764226856
         }
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -17,5 +17,5 @@
             "OlderHistory": ""
         }
     },
-    "total_package_size": "00000000000000714927"
+    "total_package_size": "00000000000000717477"
 }


### PR DESCRIPTION
Fixes #40 

**Summary of changes**
Waypoint information such as waypoint track, distance, name, etc. will now be shown on the ND only after IRS alignment is complete. 