### PR TITLE
Improved FMC VNAV CRZ page

### DIFF
--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_VNAVPage.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_VNAVPage.js
@@ -1,0 +1,106 @@
+class B747_8_FMC_VNAVPage {
+    static ShowPage1(fmc) {
+        fmc.clearDisplay();
+        let crzAltCell = "□□□□□";
+        if (fmc.cruiseFlightLevel) {
+            crzAltCell = fmc.cruiseFlightLevel + "FL";
+        }
+        fmc.onLeftInput[0] = () => {
+            let value = fmc.inOut;
+            fmc.clearUserInput();
+            if (fmc.setCruiseFlightLevelAndTemperature(value)) {
+                B747_8_FMC_VNAVPage.ShowPage1(fmc);
+            }
+        };
+        let speedTransCell = "---";
+        let speed = fmc.getCrzManagedSpeed();
+        if (isFinite(speed)) {
+            speedTransCell = speed.toFixed(0);
+        }
+        speedTransCell += "/";
+        if (isFinite(fmc.transitionAltitude)) {
+            speedTransCell += fmc.transitionAltitude.toFixed(0);
+        }
+        else {
+            speedTransCell += "-----";
+        }
+        fmc.setTemplate([
+            ["CLB", "1", "3"],
+            ["CRZ ALT"],
+            [crzAltCell],
+            ["ECON SPD"],
+            [],
+            ["SPD TRANS", "TRANS ALT"],
+            [speedTransCell],
+            ["SPD RESTR"],
+            [],
+            [],
+            ["", "<ENG OUT"],
+            [],
+            []
+        ]);
+        fmc.onNextPage = () => { B747_8_FMC_VNAVPage.ShowPage2(fmc); };
+    }
+    static ShowPage2(fmc) {
+        fmc.clearDisplay();
+        let crzAltCell = "□□□□□";
+        if (fmc.cruiseFlightLevel) {
+            crzAltCell = fmc.cruiseFlightLevel + "FL";
+        }
+        fmc.onRightInput[0] = () => {
+            let value = fmc.inOut;
+            fmc.clearUserInput();
+            if (fmc.setCruiseFlightLevelAndTemperature(value)) {
+                B747_8_FMC_VNAVPage.ShowPage2(fmc);
+            }
+        };
+        let n1Cell = "--%";
+        let n1Value = fmc.getThrustClimbLimit();
+        if (isFinite(n1Value)) {
+            n1Cell = n1Value.toFixed(1) + "%";
+        }
+        fmc.setTemplate([
+            ["CRZ", "2", "3"],
+            ["CRZ ALT", "STEP TO"],
+            [crzAltCell],
+            ["ECON SPD", "AT"],
+            [],
+            ["N1"],
+            [n1Cell],
+            ["STEP", "RECMD", "OPT MAX"],
+            [],
+            ["", "1X @ TOD"],
+            ["", "OFF"],
+            ["PAUSE @ TOD"],
+            ["OFF", "<LRC"]
+        ]);
+        fmc.onPrevPage = () => { B747_8_FMC_VNAVPage.ShowPage1(fmc); };
+        fmc.onNextPage = () => { B747_8_FMC_VNAVPage.ShowPage3(fmc); };
+    }
+    static ShowPage3(fmc) {
+        fmc.clearDisplay();
+        let speedTransCell = "---";
+        let speed = fmc.getDesManagedSpeed();
+        if (isFinite(speed)) {
+            speedTransCell = speed.toFixed(0);
+        }
+        speedTransCell += "/10000";
+        fmc.setTemplate([
+            ["DES", "3", "3"],
+            ["E/D AT"],
+            [],
+            ["ECON SPD"],
+            [],
+            ["SPD TRANS", "WPT/ALT"],
+            [speedTransCell],
+            ["SPD RESTR"],
+            [],
+            ["PAUSE @ DIST FROM DEST"],
+            ["OFF", "FORECAST>"],
+            [],
+            ["<OFFPATH DES"]
+        ]);
+        fmc.onPrevPage = () => { B747_8_FMC_VNAVPage.ShowPage2(fmc); };
+    }
+}
+//# sourceMappingURL=B747_8_FMC_VNAVPage.js.map

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_VNAVPage.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_VNAVPage.js
@@ -1,9 +1,16 @@
 class B747_8_FMC_VNAVPage {
     static ShowPage1(fmc) {
         fmc.clearDisplay();
+        B747_8_FMC_VNAVPage._timer = 0;
+        fmc.pageUpdate = () => {
+            B747_8_FMC_VNAVPage._timer++;
+            if (B747_8_FMC_VNAVPage._timer >= 100) {
+                B747_8_FMC_VNAVPage.ShowPage1(fmc);
+            }
+        };
         let crzAltCell = "□□□□□";
         if (fmc.cruiseFlightLevel) {
-            crzAltCell = fmc.cruiseFlightLevel + "FL";
+            crzAltCell = "FL" + fmc.cruiseFlightLevel;
         }
         fmc.onLeftInput[0] = () => {
             let value = fmc.inOut;
@@ -43,10 +50,32 @@ class B747_8_FMC_VNAVPage {
     }
     static ShowPage2(fmc) {
         fmc.clearDisplay();
+        B747_8_FMC_VNAVPage._timer = 0;
+        fmc.pageUpdate = () => {
+            B747_8_FMC_VNAVPage._timer++;
+            if (B747_8_FMC_VNAVPage._timer >= 100) {
+                B747_8_FMC_VNAVPage.ShowPage2(fmc);
+            }
+        };        
+        let crzPageTitle = "ACT ECON CRZ"
+        let crzSpeedMode = "ECON SPD"
+        if (SimVar.GetSimVarValue("L:AP_SPEED_INTERVENTION_ACTIVE", "number") == 1) {
+            crzPageTitle = "ACT MCP SPD CRZ"
+            crzSpeedMode = "SEL SPD"
+        }
+        let crzSpeedCell = ""
+        let machMode = Simplane.getAutoPilotMachModeActive();
+        if (machMode) {
+            let crzMachNo = Simplane.getAutoPilotMachHoldValue().toFixed(3);
+            var radixPos = crzMachNo.indexOf('.');
+            crzSpeedCell = crzMachNo.slice(radixPos);
+        } else {
+            crzSpeedCell = Simplane.getAutoPilotAirspeedHoldValue().toFixed(0);
+        }
         let crzAltCell = "□□□□□";
         if (fmc.cruiseFlightLevel) {
-            crzAltCell = fmc.cruiseFlightLevel + "FL";
-        }
+            crzAltCell = "FL" + fmc.cruiseFlightLevel;
+        }  
         fmc.onRightInput[0] = () => {
             let value = fmc.inOut;
             fmc.clearUserInput();
@@ -59,26 +88,39 @@ class B747_8_FMC_VNAVPage {
         if (isFinite(n1Value)) {
             n1Cell = n1Value.toFixed(1) + "%";
         }
+
+        let weightIndex = SimVar.GetSimVarValue("TOTAL WEIGHT", "pounds") - 608000;
+        let maxFltLevel = 431
+        if (weightIndex >= 0){
+            maxFltLevel = 431 - (weightIndex / 362000 * 110)
+        }
         fmc.setTemplate([
-            ["CRZ", "2", "3"],
+            [crzPageTitle, "2", "3"],
             ["CRZ ALT", "STEP TO"],
             [crzAltCell],
-            ["ECON SPD", "AT"],
-            [],
+            [crzSpeedMode, "AT"],
+            [crzSpeedCell],
             ["N1"],
             [n1Cell],
-            ["STEP", "RECMD", "OPT MAX"],
+            ["STEP", "RECMD", "OPT\xa0\xa0\xa0MAX"],
+            ["RVSM", "", "\xa0\xa0\xa0\xa0\xa0\xa0" + "FL" + maxFltLevel.toFixed(0)],
+            ["__FMCSEPARATOR"],
+            ["", "ENG OUT>"],
             [],
-            ["", "1X @ TOD"],
-            ["", "OFF"],
-            ["PAUSE @ TOD"],
-            ["OFF", "<LRC"]
+            ["<RTA PROGRESS", "LRC>"]
         ]);
         fmc.onPrevPage = () => { B747_8_FMC_VNAVPage.ShowPage1(fmc); };
         fmc.onNextPage = () => { B747_8_FMC_VNAVPage.ShowPage3(fmc); };
     }
     static ShowPage3(fmc) {
         fmc.clearDisplay();
+        B747_8_FMC_VNAVPage._timer = 0;
+        fmc.pageUpdate = () => {
+            B747_8_FMC_VNAVPage._timer++;
+            if (B747_8_FMC_VNAVPage._timer >= 100) {
+                B747_8_FMC_VNAVPage.ShowPage3(fmc);
+            }
+        };
         let speedTransCell = "---";
         let speed = fmc.getDesManagedSpeed();
         if (isFinite(speed)) {

--- a/layout.json
+++ b/layout.json
@@ -127,8 +127,8 @@
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_VNAVPage.js",
-            "size": 3330,
-            "date": 132482861536786054
+            "size": 5103,
+            "date": 132482979669772210
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.html",

--- a/layout.json
+++ b/layout.json
@@ -3,267 +3,272 @@
         {
             "path": "html_ui/Pages/Salty/SaltyBase.js",
             "size": 182,
-            "date": 132477731236209828
+            "date": 132481255336780588
         },
         {
             "path": "html_ui/Pages/Salty/SaltyIRS.js",
             "size": 1607,
-            "date": 132477731236249838
+            "date": 132481255336790588
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.html",
             "size": 3721,
-            "date": 132477747887500542
+            "date": 132481255336800592
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.js",
             "size": 5165,
-            "date": 132477747887500542
+            "date": 132481255336800592
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.css",
             "size": 1102,
-            "date": 132477731236449890
+            "date": 132481255336810594
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.html",
             "size": 4352,
-            "date": 132477731236769964
+            "date": 132481255336810594
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.js",
             "size": 2526,
-            "date": 132477731236769964
+            "date": 132481255336820596
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_ELEC.css",
             "size": 1883,
-            "date": 132477731236819970
+            "date": 132481255336820596
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_ELEC.html",
             "size": 14074,
-            "date": 132477731237010010
+            "date": 132481255336820596
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_ELEC.js",
             "size": 22325,
-            "date": 132477731237070026
+            "date": 132481255336830596
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_FCTL.css",
             "size": 1085,
-            "date": 132477731237120040
+            "date": 132481255336830596
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_FCTL.html",
             "size": 11319,
-            "date": 132477731237160048
+            "date": 132481255336840600
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_FCTL.js",
             "size": 8580,
-            "date": 132477731237340084
+            "date": 132481255336840600
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_GEAR.css",
             "size": 1388,
-            "date": 132477747887500542
+            "date": 132481255336840600
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_GEAR.html",
             "size": 7826,
-            "date": 132477747887510546
+            "date": 132481255336850602
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_GEAR.js",
             "size": 1599,
-            "date": 132477747887510546
+            "date": 132481255336850602
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Stat.css",
             "size": 1026,
-            "date": 132477731237410100
+            "date": 132481255336860604
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Stat.html",
             "size": 3122,
-            "date": 132477731237650164
+            "date": 132481255336860604
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Stat.js",
             "size": 2177,
-            "date": 132477731237800188
+            "date": 132481255336860604
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC.html",
             "size": 4893,
-            "date": 132477731237850206
+            "date": 132482861103306696
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js",
             "size": 35967,
-            "date": 132480416222344012
+            "date": 132482861013010184
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplayPages.js",
             "size": 1801,
-            "date": 132477731237930220
+            "date": 132481255336880610
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_PerfInitPage.js",
             "size": 3005,
-            "date": 132477747887520538
+            "date": 132481255336880610
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_SaltyOptions.js",
             "size": 1274,
-            "date": 132477731238220288
+            "date": 132481255336880610
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_TakeOffPage.js",
             "size": 5797,
-            "date": 132477731238230288
+            "date": 132481255336890612
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_VNAVPage.js",
+            "size": 3330,
+            "date": 132482861536786054
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.html",
             "size": 9919,
-            "date": 132477747887520538
+            "date": 132481804613431968
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.js",
             "size": 24395,
-            "date": 132477747887530548
+            "date": 132481255336900616
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/Salty_BaseNDCompass.js",
             "size": 36530,
-            "date": 132477731238450338
+            "date": 132481255336900616
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/Salty_NDCompass.js",
             "size": 48727,
-            "date": 132477731238540356
+            "date": 132481255336910618
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/AirspeedIndicator.js",
             "size": 64537,
-            "date": 132477731238680396
+            "date": 132481255336920620
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/AttitudeIndicator.js",
             "size": 40886,
-            "date": 132477731238750408
+            "date": 132481255336920620
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.css",
             "size": 3504,
-            "date": 132477731238900442
+            "date": 132481255336930618
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.html",
             "size": 5919,
-            "date": 132477731238950448
+            "date": 132481255336930618
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.js",
             "size": 8895,
-            "date": 132477731238950448
+            "date": 132481255336940624
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.css",
             "size": 3416,
-            "date": 132477731239170506
+            "date": 132481255336940624
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.html",
             "size": 1191,
-            "date": 132477731239210512
+            "date": 132481255336950626
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js",
             "size": 18979,
-            "date": 132477731239400558
+            "date": 132481255336950626
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/approach.FLT",
             "size": 5193,
-            "date": 132477731234629474
+            "date": 132481255336710570
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/apron.FLT",
             "size": 5059,
-            "date": 132477731234719506
+            "date": 132481255336720582
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/Climb.flt",
             "size": 5198,
-            "date": 132477731234319412
+            "date": 132481255336710570
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/cruise.FLT",
             "size": 5193,
-            "date": 132477731234929542
+            "date": 132481255336720582
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/engines.cfg",
             "size": 7130,
-            "date": 132480416221753792
+            "date": 132481255336720582
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/final.FLT",
             "size": 5201,
-            "date": 132477731235149600
+            "date": 132481255336730576
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/flight_model.cfg",
             "size": 43947,
-            "date": 132480416221763782
+            "date": 132481255336730576
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/hangar.flt",
             "size": 4172,
-            "date": 132477731235369646
+            "date": 132481255336740580
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/runway.FLT",
             "size": 5058,
-            "date": 132477731235959774
+            "date": 132481255336760582
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/taxi.FLT",
             "size": 4987,
-            "date": 132477731236009786
+            "date": 132481255336770586
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/model/747_8I_INTERIOR.xml",
-            "size": 186079,
-            "date": 132480416222123960
+            "size": 185955,
+            "date": 132481255336750582
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/panel/panel.cfg",
             "size": 2508,
-            "date": 132477731235659712
+            "date": 132481255336750582
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/panel/panel.xml",
             "size": 23014,
-            "date": 132477747887490530
+            "date": 132481255336760582
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/TEXTURE/B747_COCKPIT_TEXTS_EMISSIVE.TIF.DDS",
             "size": 4194432,
-            "date": 132480416001275184
+            "date": 132481808335640110
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/TEXTURE/B747_COCKPIT_TEXTS_EMISSIVE.TIF.DDS.json",
             "size": 102,
-            "date": 132477730265115760
+            "date": 132481808335650116
         },
         {
             "path": "ModelBehaviorDefs/Asobo/Airliner/Boeing.xml",
-            "size": 45356,
-            "date": 132477731234059358
+            "size": 46397,
+            "date": 132481255336690566
         }
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -17,5 +17,5 @@
             "OlderHistory": ""
         }
     },
-    "total_package_size": "00000000000004957323"
+    "total_package_size": "00000000000004961570"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -17,5 +17,5 @@
             "OlderHistory": ""
         }
     },
-    "total_package_size": "00000000000004961570"
+    "total_package_size": "00000000000004963343"
 }


### PR DESCRIPTION
Added some features to VNAV CRZ page on the FMC

- Page now refreshes automatically instead of on input
- Shows in title if ECON or MCP speed mode is active 
- Displays current command speed (was previously blank)
- Shows maximum operating flight level based on current aircraft weight
- Miscellaneous visual accuracy improvements

TO DO:
-Add step climb estimates
-Destination ETA and fuel
-Optimum and Recommended FL