### PR TITLE
 Ported Progress Features to Asobo base page

### DIFF
--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_ProgPage.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_ProgPage.js
@@ -87,7 +87,7 @@ class B747_8_FMC_ProgPage {
             destinationCell = destination.ident;
             destinationDistance = destination.cumulativeDistanceInFP;
             if (waypointActive) {
-                destinationDistance -= waypointActive.distanceInFP;
+                destinationDistance -= waypointActive.cumulativeDistanceInFP;
                 destinationDistance += fmc.flightPlanManager.getDistanceToActiveWaypoint();
                 if (isFinite(destinationDistance)) {
                     for (let i = 0; i < 3 - Math.log10(destinationDistance); i++) {

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_ProgPage.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_ProgPage.js
@@ -121,13 +121,13 @@ class B747_8_FMC_ProgPage {
             }
         fmc.setTemplate([
             [progressTitle],
-            ["TO", "FUEL", "DTG\xa0\xa0ETA"],
+            ["\xa0TO", "FUEL", "DTG\xa0\xa0ETA"],
             [waypointActiveCell + "[color]magenta", waypointActiveFuelCell, waypointActiveDistanceCell],
-            ["NEXT"],
+            ["\xa0NEXT", "", "\xa0\xa0\xa0\xa0\xa0ETA"],
             [waypointActiveNextCell, waypointActiveNextFuelCell, waypointActiveNextDistanceCell],
-            ["DEST"],
+            ["\xa0DEST"],
             [destinationCell, destinationFuelCell, destinationDistanceCell],
-            ["SEL SPD"],
+            ["\xa0SEL SPD"],
             [crzSpeedCell],
             [],
             [""],

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_ProgPage.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_ProgPage.js
@@ -4,139 +4,151 @@ class B747_8_FMC_ProgPage {
         B747_8_FMC_ProgPage._timer = 0;
         fmc.pageUpdate = () => {
             B747_8_FMC_ProgPage._timer++;
-            if (B747_8_FMC_ProgPage._timer >= 100) {
+            if (B747_8_FMC_ProgPage._timer >= 15) {
                 B747_8_FMC_ProgPage.ShowPage1(fmc);
             }
         };
-        
-        let progressTitle = SimVar.GetSimVarValue("ATC FLIGHT NUMBER", "string") + " PROGRESS";
-        let currentFuelBurn = (SimVar.GetSimVarValue("TURB ENG CORRECTED FF:1", "pounds per hour") + SimVar.GetSimVarValue("TURB ENG CORRECTED FF:2", "pounds per hour") + SimVar.GetSimVarValue("TURB ENG CORRECTED FF:3", "pounds per hour") + SimVar.GetSimVarValue("TURB ENG CORRECTED FF:4", "pounds per hour") / 1000);
-        let utcTime = SimVar.GetGlobalVarValue("ZULU TIME", "seconds");
-        let timeToActivePoint = SimVar.GetSimVarValue("GPS WP ETE", "seconds"); 
-        let flightPlanIndex = fmc.flightPlanManager.getActiveWaypointIndex(); 
-        
-        let activeWaypoint = ""
-        let activeWaypointDTG = ""
-        let activeWaypointDTGCell = ""
-        let activeWaypointETACell = ""
-        let activeWaypointFuel = ""
-        let activeWaypointFuelCell = ""
-        
-        let nextWaypoint = ""
-        let nextWaypointDistance =""
-        let nextWaypointDTG = ""
-        let nextWaypointDTGCell = ""
-        let nextWaypointETACell = ""
-        let nextWaypointFuel = ""
-        let nextWaypointFuelCell = ""
-
-        let destination = ""
-        let destinationDTG = ""
-        let destinationDTGCell = ""
-        let destinationETACell = ""   
-        let destinationFuel = ""
-        let destinationFuelCell = ""
-        
-        let crzSpeedCell = ""
-        let distanceToTODCell = ""
-        let todETACell = ""
-
-        //Active Waypoint Distance, ETA, Fuel Estimate
-        if (fmc.flightPlanManager.getWaypoint(flightPlanIndex, undefined, true)){
-            activeWaypoint = fmc.flightPlanManager.getWaypoint(flightPlanIndex, undefined, true);
-            activeWaypointDTG = Simplane.getNextWaypointDistance();
-            activeWaypointDTGCell = activeWaypointDTG.toFixed(0);
-            if (SimVar.GetSimVarValue("SIM ON GROUND", "bool") == 0) {
-                let wpETE = timeToActivePoint;
-                let utcETA = wpETE > 0 ? (utcTime + wpETE) % 86400 : 0;
-                const hours = Math.floor(utcETA / 3600);
-                const minutes = Math.floor((utcETA % 3600) / 60);
-                activeWaypointETACell = `${hours.toString().padStart(2, "0")}${minutes.toString().padStart(2, "0")}z`;
-                activeWaypointFuel = ((SimVar.GetSimVarValue("FUEL TOTAL QUANTITY", "gallons") * 0.0067) - ((wpETE /3600) * (currentFuelBurn / 1000)));
-                activeWaypointFuelCell = activeWaypointFuel.toFixed(1);
+        let planeCoordinates = new LatLong(SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude"), SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude"));
+        let waypointFromCell = "";
+        let waypointFromAltAtaCell = "";
+        let waypointFromFuelCell = "";
+        let waypointFrom;
+        if (fmc.flightPlanManager.getActiveWaypointIndex() === -1) {
+            waypointFrom = fmc.flightPlanManager.getOrigin();
+        }
+        else {
+            waypointFrom = fmc.flightPlanManager.getPreviousActiveWaypoint();
+        }
+        if (waypointFrom) {
+            waypointFromCell = waypointFrom.ident;
+            if (isFinite(waypointFrom.altitudeWasReached) && isFinite(waypointFrom.timeWasReached)) {
+                let t = waypointFrom.timeWasReached;
+                let hours = Math.floor(t / 3600);
+                let minutes = Math.floor((t - hours * 3600) / 60);
+                for (let i = 0; i < 4 - Math.log10(waypointFrom.altitudeWasReached); i++) {
+                    waypointFromAltAtaCell += "&nbsp";
+                }
+                waypointFromAltAtaCell += waypointFrom.altitudeWasReached.toFixed(0) + " " + hours.toFixed(0).padStart(2, "0") + minutes.toFixed(0).padStart(2, "0") + "&nbsp";
+            }
+            if (isFinite(waypointFrom.fuelWasReached)) {
+                waypointFromFuelCell = waypointFrom.getFuelWasReached(true).toFixed(0);
             }
         }
-        //Next Waypoint Distance, ETA, Fuel Estimate
-        if (fmc.flightPlanManager.getWaypoint(flightPlanIndex + 1, undefined, true)){
-            nextWaypoint = fmc.flightPlanManager.getWaypoint(flightPlanIndex + 1, undefined, true);
-            nextWaypointDistance = Avionics.Utils.computeGreatCircleDistance(activeWaypoint.infos.coordinates, nextWaypoint.infos.coordinates);
-            nextWaypointDTG = (activeWaypointDTG + nextWaypointDistance);
-            nextWaypointDTGCell = nextWaypointDTG.toFixed(0);
-            if (SimVar.GetSimVarValue("SIM ON GROUND", "bool") == 0) {
-                let wpETE = timeToActivePoint + (nextWaypointDistance / SimVar.GetSimVarValue("GROUND VELOCITY", "knots") * 3600);
-                let utcETA = wpETE > 0 ? (utcTime + wpETE) % 86400 : 0;
-                const hours = Math.floor(utcETA / 3600);
-                const minutes = Math.floor((utcETA % 3600) / 60);
-                nextWaypointETACell = `${hours.toString().padStart(2, "0")}${minutes.toString().padStart(2, "0")}z`;
-                nextWaypointFuel = ((SimVar.GetSimVarValue("FUEL TOTAL QUANTITY", "gallons") * 0.0067) - ((wpETE /3600) * (currentFuelBurn / 1000)));
-                nextWaypointFuelCell = nextWaypointFuel.toFixed(1);
-            }        
-        }
-        //Destination airport, ETA, Fuel Estimate
-        if (fmc.flightPlanManager.getDestination()){
-            destination = fmc.flightPlanManager.getDestination();
-            destinationDTG = destination.infos.totalDistInFP - activeWaypoint.infos.totalDistInFP + activeWaypointDTG;
-            destinationDTGCell = destinationDTG.toFixed(0);
-            if (SimVar.GetSimVarValue("SIM ON GROUND", "bool") == 0) {
-                let wpETE = destinationDTG / SimVar.GetSimVarValue("GROUND VELOCITY", "knots") * 3600; 
-                let utcETA = wpETE > 0 ? (utcTime + wpETE) % 86400 : 0;
-                const hours = Math.floor(utcETA / 3600);
-                const minutes = Math.floor((utcETA % 3600) / 60);
-                destinationETACell = `${hours.toString().padStart(2, "0")}${minutes.toString().padStart(2, "0")}z`;
-                destinationFuel = ((SimVar.GetSimVarValue("FUEL TOTAL QUANTITY", "gallons") * 0.0067) - ((wpETE /3600) * (currentFuelBurn / 1000)));
-                destinationFuelCell = destinationFuel.toFixed(1);
+        let speed = Simplane.getGroundSpeed();
+        let currentTime = SimVar.GetGlobalVarValue("LOCAL TIME", "seconds");
+        let currentFuel = SimVar.GetSimVarValue("FUEL TOTAL QUANTITY", "gallons") * SimVar.GetSimVarValue("FUEL WEIGHT PER GALLON", "pounds") / 1000;
+        let currentFuelFlow = SimVar.GetSimVarValue("TURB ENG FUEL FLOW PPH:1", "pound per hour") + SimVar.GetSimVarValue("TURB ENG FUEL FLOW PPH:2", "pound per hour") + SimVar.GetSimVarValue("TURB ENG FUEL FLOW PPH:3", "pound per hour") + SimVar.GetSimVarValue("TURB ENG FUEL FLOW PPH:4", "pound per hour");
+        currentFuelFlow = currentFuelFlow / 1000;
+        let waypointActiveCell = "";
+        let waypointActiveDistanceCell = "";
+        let waypointActiveFuelCell = "";
+        let waypointActive = fmc.flightPlanManager.getActiveWaypoint();
+        let waypointActiveDistance = NaN;
+        if (waypointActive) {
+            waypointActiveCell = waypointActive.ident;
+            waypointActiveDistance = Avionics.Utils.computeGreatCircleDistance(planeCoordinates, waypointActive.infos.coordinates);
+            if (isFinite(waypointActiveDistance)) {
+                for (let i = 0; i < 3 - Math.log10(waypointActiveDistance); i++) {
+                    waypointActiveDistanceCell += "&nbsp";
+                }
+                waypointActiveDistanceCell += waypointActiveDistance.toFixed(0) + " ";
+                let eta = fmc.computeETA(waypointActiveDistance, speed, currentTime);
+                if (isFinite(eta)) {
+                    let etaHours = Math.floor(eta / 3600);
+                    let etaMinutes = Math.floor((eta - etaHours * 3600) / 60);
+                    waypointActiveDistanceCell += etaHours.toFixed(0).padStart(2, "0") + etaMinutes.toFixed(0).padStart(2, "0") + "&nbsp";
+                }
+                else {
+                    waypointActiveDistanceCell += "&nbsp&nbsp&nbsp&nbsp&nbsp";
+                }
+                let fuelLeft = fmc.computeFuelLeft(waypointActiveDistance, speed, currentFuel, currentFuelFlow);
+                if (isFinite(fuelLeft)) {
+                    waypointActiveFuelCell = fuelLeft.toFixed(0);
+                }
             }
         }
-        //Shows TOD when within 200 miles of destination and in cruise flight
-        //TOD Calculation based on descent from VNAV crz altitude from FMC to airport elevation - TOD Distance based on 3.5NM per 1000 feet + 12NM deceleration still wind as per FCTM
-        if(fmc.flightPlanManager.getDestination() && (destinationDTG <= 200) && (Simplane.getCurrentFlightPhase() === FlightPhase.FLIGHT_PHASE_CRUISE)){
-            let crzAlt = fmc.cruiseFlightLevel * 100;
-            let destAlt = destination.infos.coordinates.alt;
-            let descentAlt = crzAlt - destAlt;
-            let descentDistance = (3.5 * descentAlt / 1000) + 12;
-            let distanceToTOD = destinationDTG - descentDistance;
-            distanceToTODCell = distanceToTOD.toFixed(0) + "NM";
-            let todETE = SimVar.GetSimVarValue("GPS WP ETE", "seconds") + ((destinationDTG - descentDistance) / SimVar.GetSimVarValue("GROUND VELOCITY", "knots") * 3600);
-            let todETA = todETE > 0 ? (utcTime + todETE) % 86400 : 0;
-            const todHours = Math.floor(todETA / 3600);
-            const todMinutes = Math.floor((todETA % 3600) / 60);
-            todETACell = `${todHours.toString().padStart(2, "0")}${todMinutes.toString().padStart(2, "0")}z/`;
-            if (distanceToTOD <= 0){
-                todETACell = "";
-                distanceToTODCell = "NOW";
+        let waypointActiveNextCell = "";
+        let waypointActiveNext;
+        let waypointActiveNextDistanceCell = "";
+        let waypointActiveNextFuelCell = "";
+        let waypointActiveNextDistance = NaN;
+        if (fmc.flightPlanManager.getActiveWaypointIndex() != -1) {
+            waypointActiveNext = fmc.flightPlanManager.getNextActiveWaypoint();
+            if (waypointActiveNext) {
+                waypointActiveNextCell = waypointActiveNext.ident;
+                if (waypointActive && isFinite(waypointActiveDistance)) {
+                    let d = Avionics.Utils.computeGreatCircleDistance(waypointActive.infos.coordinates, waypointActiveNext.infos.coordinates);
+                    if (isFinite(d)) {
+                        waypointActiveNextDistance = d + waypointActiveDistance;
+                        for (let i = 0; i < 3 - Math.log10(waypointActiveNextDistance); i++) {
+                            waypointActiveNextDistanceCell += "&nbsp";
+                        }
+                        waypointActiveNextDistanceCell += waypointActiveNextDistance.toFixed(0) + " ";
+                        let eta = fmc.computeETA(waypointActiveNextDistance, speed, currentTime);
+                        if (isFinite(eta)) {
+                            let etaHours = Math.floor(eta / 3600);
+                            let etaMinutes = Math.floor((eta - etaHours * 3600) / 60);
+                            waypointActiveNextDistanceCell += etaHours.toFixed(0).padStart(2, "0") + etaMinutes.toFixed(0).padStart(2, "0") + "&nbsp";
+                        }
+                        else {
+                            waypointActiveNextDistanceCell += "&nbsp&nbsp&nbsp&nbsp&nbsp";
+                        }
+                        let fuelLeft = fmc.computeFuelLeft(waypointActiveNextDistance, speed, currentFuel, currentFuelFlow);
+                        if (isFinite(fuelLeft)) {
+                            waypointActiveNextFuelCell = fuelLeft.toFixed(0);
+                        }
+                    }
+                }
             }
-            if (((SimVar.GetSimVarValue("INDICATED ALTITUDE", "feet") - 200 ) > crzAlt)){
-                todETACell = "";
-                distanceToTODCell = "";
-            }        
         }
-        //Gets current command speed/mach from FMC    
-        let machMode = Simplane.getAutoPilotMachModeActive();
-        if (machMode) {
-            let crzMachNo = Simplane.getAutoPilotMachHoldValue().toFixed(3);
-            var radixPos = crzMachNo.indexOf('.');
-            crzSpeedCell = crzMachNo.slice(radixPos);
-        } else {
-            crzSpeedCell = Simplane.getAutoPilotAirspeedHoldValue().toFixed(0);
+        let destinationCell = "";
+        let destination = fmc.flightPlanManager.getDestination();
+        let destinationDistanceCell = "";
+        let destinationFuelCell = "";
+        let destinationDistance = NaN;
+        if (destination) {
+            destinationCell = destination.ident;
+            destinationDistance = destination.cumulativeDistanceInFP;
+            if (waypointActive) {
+                destinationDistance -= waypointActive.distanceInFP;
+                destinationDistance += fmc.flightPlanManager.getDistanceToActiveWaypoint();
+                if (isFinite(destinationDistance)) {
+                    for (let i = 0; i < 3 - Math.log10(destinationDistance); i++) {
+                        destinationDistanceCell += "&nbsp";
+                    }
+                    destinationDistanceCell += destinationDistance.toFixed(0) + " ";
+                    let eta = fmc.computeETA(destinationDistance, speed, currentTime);
+                    if (isFinite(eta)) {
+                        let etaHours = Math.floor(eta / 3600);
+                        let etaMinutes = Math.floor((eta - etaHours * 3600) / 60);
+                        destinationDistanceCell += etaHours.toFixed(0).padStart(2, "0") + etaMinutes.toFixed(0).padStart(2, "0") + "&nbsp";
+                    }
+                    else {
+                        destinationDistanceCell += "&nbsp&nbsp&nbsp&nbsp&nbsp";
+                    }
+                    let fuelLeft = fmc.computeFuelLeft(destinationDistance, speed, currentFuel, currentFuelFlow);
+                    if (isFinite(fuelLeft)) {
+                        destinationFuelCell = fuelLeft.toFixed(0);
+                    }
+                }
+            }
         }
-        //Draw values to FMC, concatenated strings and forced spaces required due to limitation of setTemplate function to only 3 values per row
         fmc.setTemplate([
-            [progressTitle],
-            ["TO", "FUEL", "DTG\xa0\xa0\xa0\xa0ETA"],  
-            [activeWaypoint.ident, activeWaypointFuelCell, activeWaypointDTGCell + "\xa0\xa0\xa0" +  activeWaypointETACell],
-            ["NEXT"],
-            [nextWaypoint.ident, nextWaypointFuelCell, nextWaypointDTGCell + "\xa0\xa0\xa0" +  nextWaypointETACell],
-            ["DEST"],
-            [destination.ident, destinationFuelCell, destinationDTGCell + "\xa0\xa0\xa0" + destinationETACell],
-            ["SEL SPD", "TO T/D"],
-            [crzSpeedCell, todETACell + distanceToTODCell],
-            [],
-            [],
-            ["__FMCSEPARATOR"],
-            ["<POS REPORT", "POS REF>"]
-        ]);  
+            ["PROGRESS"],
+            ["FROM", "FUEL", "ALT ATA"],
+            [waypointFromCell, waypointFromFuelCell, waypointFromAltAtaCell],
+            ["", "FUEL", "DTG ETA"],
+            [waypointActiveCell, waypointActiveFuelCell, waypointActiveDistanceCell],
+            [""],
+            [waypointActiveNextCell, waypointActiveNextFuelCell, waypointActiveNextDistanceCell],
+            [""],
+            [destinationCell, destinationFuelCell, destinationDistanceCell],
+            ["TO T/D", "FUEL QTY"],
+            [""],
+            ["WIND"],
+            ["", "NAV STATUS>"]
+        ]);
     }
 }
-
-
+B747_8_FMC_ProgPage._timer = 0;
 //# sourceMappingURL=B747_8_FMC_ProgPage.js.map


### PR DESCRIPTION
Features from the previous progress page 1 implementation have been ported using the asobo default page as a base.

Differences from Asobo default include:
- Added ATC callsign to page title
- All ETAs now adjusted from local time to UTC
- Fuel estimates display to nearest 100lbs
- Added SEL SPD field showing current command speed or Mach
- Changed Layout to match real aircraft
- Deleted incorrect fields not present on real aircraft 

Note: T/D function has been disabled due to inaccuracies & needing improvement to logic.
Note: Active Waypoint should display Magenta, however Fmc.SetLine function does not seem to accept this as a valid colour.

FCOM Reference:
![image](https://user-images.githubusercontent.com/71572892/104820368-31aa9400-582c-11eb-87c4-04ce49121445.png)


