### PR TITLE
VNAV

### DIFF
--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.html
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.html
@@ -37,7 +37,7 @@
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/NavSystems/Shared/LogicElements/GaugeElement.js"></script>
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/Shared/BaseAirliners.js"></script>
-<script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/Shared/Boeing/Boeing_Common.js"></script>
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Boeing_Common.js"></script> <!--modified-->
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_EICASGauge.js"></script>
 

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Boeing_Common.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Boeing_Common.js
@@ -9,8 +9,14 @@ var Boeing;
         }
         getText(phase, mode) {
             let text = "-";
+            let alt = Simplane.getAltitude();
+            let thrRedAlt = SimVar.GetSimVarValue("L:AIRLINER_THR_RED_ALT", "number");
             if (phase <= FlightPhase.FLIGHT_PHASE_TAKEOFF) {
-                text = "TO";
+                if (alt <= thrRedAlt){
+                    text = "TO"
+                } else {
+                    text = "CLB";
+                }
                 if (mode === 1) {
                     text += " - 1";
                 }
@@ -35,7 +41,9 @@ var Boeing;
         update() {
             let phase = Simplane.getCurrentFlightPhase();
             let mode = 0;
-            if (phase <= FlightPhase.FLIGHT_PHASE_TAKEOFF) {
+            let alt = Simplane.getAltitude();
+            let thrRedAlt = SimVar.GetSimVarValue("L:AIRLINER_THR_RED_ALT", "number");
+            if (phase <= FlightPhase.FLIGHT_PHASE_TAKEOFF && alt < thrRedAlt) {
                 mode = Simplane.getEngineThrustTakeOffMode(0);
             }
             else {

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Boeing_Common.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Boeing_Common.js
@@ -1,0 +1,592 @@
+var Boeing;
+(function (Boeing) {
+    class ThrustModeDisplay {
+        constructor(_rootElement) {
+            this.rootElement = null;
+            this.currentText = "";
+            this.rootElement = _rootElement;
+            this.refresh("", true);
+        }
+        getText(phase, mode) {
+            let text = "-";
+            if (phase <= FlightPhase.FLIGHT_PHASE_TAKEOFF) {
+                text = "TO";
+                if (mode === 1) {
+                    text += " - 1";
+                }
+                if (mode === 2) {
+                    text += " - 2";
+                }
+            }
+            else if (phase <= FlightPhase.FLIGHT_PHASE_CLIMB) {
+                text = "CLB";
+                if (mode === 1) {
+                    text += " - 1";
+                }
+                if (mode === 2) {
+                    text += " - 2";
+                }
+            }
+            else if (phase <= FlightPhase.FLIGHT_PHASE_CRUISE) {
+                text = "CRZ";
+            }
+            return text;
+        }
+        update() {
+            let phase = Simplane.getCurrentFlightPhase();
+            let mode = 0;
+            if (phase <= FlightPhase.FLIGHT_PHASE_TAKEOFF) {
+                mode = Simplane.getEngineThrustTakeOffMode(0);
+            }
+            else {
+                mode = Simplane.getEngineThrustClimbMode(0);
+            }
+            let tmaText = this.getText(phase, mode);
+            this.refresh(tmaText);
+        }
+        refresh(_text, _force = false) {
+            if ((_text != this.currentText) || _force) {
+                this.currentText = _text;
+                if (this.rootElement != null) {
+                    this.rootElement.innerHTML = this.currentText;
+                }
+            }
+        }
+    }
+    Boeing.ThrustModeDisplay = ThrustModeDisplay;
+    class GearDisplay {
+        constructor(_rootElement) {
+            this.rootElement = null;
+            this.currentValue = 0;
+            this.timeout = 0;
+            this.rootElement = _rootElement;
+            this.refreshValue(0, true);
+        }
+        update(_deltaTime) {
+            this.refreshValue(Simplane.getGearPosition());
+            if ((this.currentValue <= 0) && (this.timeout > 0)) {
+                this.timeout -= _deltaTime;
+                if (this.timeout <= 0) {
+                    if (this.rootElement != null) {
+                        this.rootElement.setAttribute("class", "inactive");
+                    }
+                }
+            }
+        }
+        refreshValue(_value, _force = false) {
+            if ((_value != this.currentValue) || _force) {
+                this.currentValue = _value;
+                if (this.rootElement != null) {
+                    if (this.currentValue <= 0) {
+                        this.rootElement.setAttribute("class", "up");
+                    }
+                    else if (this.currentValue >= 100) {
+                        this.rootElement.setAttribute("class", "down");
+                    }
+                    else {
+                        this.rootElement.setAttribute("class", "transit");
+                    }
+                }
+                if (this.currentValue <= 0) {
+                    this.timeout = Boeing.GearDisplay.TIMEOUT_LENGTH;
+                }
+            }
+        }
+    }
+    GearDisplay.TIMEOUT_LENGTH = 10000;
+    Boeing.GearDisplay = GearDisplay;
+    class FlapsDisplay {
+        constructor(_rootElement, _marker, _valueText, _bar, _gauge) {
+            this.rootElement = _rootElement;
+            this.marker = _marker;
+            this.valueText = _valueText;
+            this.bar = _bar;
+            this.gauge = _gauge;
+            this.cockpitSettings = SimVar.GetGameVarValue("", "GlassCockpitSettings");
+            this.refreshValue(0, 0, 0, true);
+        }
+        update(_deltaTime) {
+            var leverPos = Simplane.getFlapsHandleIndex();
+            var flapsPercent = ((SimVar.GetSimVarValue("TRAILING EDGE FLAPS LEFT PERCENT", "percent") + SimVar.GetSimVarValue("TRAILING EDGE FLAPS RIGHT PERCENT", "percent")) * 0.5) * 0.01;
+            var flapsAngle = (SimVar.GetSimVarValue("TRAILING EDGE FLAPS LEFT ANGLE", "degrees") + SimVar.GetSimVarValue("TRAILING EDGE FLAPS RIGHT ANGLE", "degrees")) * 0.5;
+            this.refreshValue(leverPos, flapsPercent, flapsAngle);
+            if ((this.currentAngle <= 0) && (this.timeout > 0)) {
+                this.timeout -= _deltaTime;
+                if (this.timeout <= 0) {
+                    if (this.rootElement != null) {
+                        this.rootElement.setAttribute("class", "inactive");
+                    }
+                }
+            }
+        }
+        refreshValue(_leverPos, _realFlapsPercent, _realFlapsAngle, _force = false) {
+            if ((_leverPos != this.currentLeverPosition) || (_realFlapsPercent != this.currentPercent) || (_realFlapsAngle != this.currentAngle) || _force) {
+                this.currentLeverPosition = _leverPos;
+                this.currentPercent = _realFlapsPercent;
+                this.currentAngle = _realFlapsAngle;
+                var targetAngle = this.flapsLeverPositionToAngle(this.currentLeverPosition);
+                var barTop = 0;
+                var barBottom = 0;
+                var barHeight = 0;
+                if (this.bar != null) {
+                    barTop = this.bar.y.baseVal.value;
+                    barBottom = barTop + this.bar.height.baseVal.value;
+                    barHeight = (barBottom - barTop);
+                }
+                var markerY = barTop + (barHeight * this.currentPercent);
+                var markerYStr = markerY.toString();
+                if (this.marker != null) {
+                    this.marker.setAttribute("y1", markerYStr);
+                    this.marker.setAttribute("y2", markerYStr);
+                }
+                if (this.valueText != null) {
+                    this.valueText.textContent = (targetAngle <= 0) ? "UP" : targetAngle.toFixed(0);
+                    this.valueText.setAttribute("y", markerYStr);
+                }
+                if (this.gauge != null) {
+                    var height = barHeight * this.currentPercent;
+                    this.gauge.setAttribute("height", height.toString());
+                }
+                if (this.rootElement != null) {
+                    this.rootElement.setAttribute("class", (Math.round(this.currentAngle) == Math.round(targetAngle)) ? "static" : "transit");
+                }
+                if (this.currentAngle <= 0) {
+                    this.timeout = Boeing.FlapsDisplay.TIMEOUT_LENGTH;
+                }
+            }
+        }
+        flapsLeverPositionToAngle(_leverPos) {
+            if (this.cockpitSettings && this.cockpitSettings.FlapsLevels.initialised) {
+                return this.cockpitSettings.FlapsLevels.flapsAngle[_leverPos];
+            }
+            return Simplane.getFlapsHandleAngle(_leverPos);
+        }
+    }
+    FlapsDisplay.TIMEOUT_LENGTH = 3000;
+    Boeing.FlapsDisplay = FlapsDisplay;
+    class StabDisplay {
+        constructor(_root, _maxValue = 20, _valueDecimals = 2) {
+            this.currentValue = 0;
+            this.maxValue = 0;
+            this.valueDecimals = 0;
+            this.valueToArrowY = 0;
+            this.takeoffText = null;
+            this.valueText = null;
+            this.arrow = null;
+            this.trimBand = null;
+            this.maxValue = _maxValue;
+            this.valueDecimals = _valueDecimals;
+            if (_root != null) {
+                this.takeoffText = _root.querySelector(".takeoff");
+                this.valueText = _root.querySelector(".value");
+                this.arrow = _root.querySelector(".arrow");
+                this.trimBand = _root.querySelector(".trimBand");
+                var bar = _root.querySelector(".bar");
+                if (bar != null) {
+                    var barHeight = bar.y2.baseVal.value - bar.y1.baseVal.value;
+                    this.valueToArrowY = (barHeight * 0.5) / this.maxValue;
+                }
+                if (this.takeoffText != null) {
+                    this.takeoffText.style.display = "none";
+                }
+            }
+            this.refreshValue(0, true);
+        }
+        update(_deltaTime) {
+            this.refreshValue(SimVar.GetSimVarValue("ELEVATOR TRIM POSITION", "degree"));
+        }
+        refreshValue(_value, _force = false) {
+            if ((_value != this.currentValue) || _force) {
+                this.currentValue = Utils.Clamp(_value, 0, this.maxValue);
+                var displayValue = (this.currentValue + this.maxValue) * 0.5;
+                if (this.valueText != null) {
+                    this.valueText.textContent = displayValue.toFixed(this.valueDecimals);
+                }
+                if (this.arrow != null) {
+                    let clampedVal = Utils.Clamp(this.currentValue, -this.maxValue, this.maxValue);
+                    var arrowY = clampedVal * this.valueToArrowY;
+                    this.arrow.setAttribute("transform", "translate(0," + arrowY + ")");
+                }
+            }
+        }
+    }
+    Boeing.StabDisplay = StabDisplay;
+    class RudderDisplay {
+        constructor(_root, _maxValue = 10) {
+            this.currentValue = 0;
+            this.maxValue = 0;
+            this.valueToArrowX = 0;
+            this.valueText = null;
+            this.leftText = null;
+            this.rightText = null;
+            this.arrow = null;
+            this.maxValue = _maxValue;
+            if (_root != null) {
+                this.valueText = _root.querySelector(".value");
+                this.leftText = _root.querySelector(".left");
+                this.rightText = _root.querySelector(".right");
+                this.arrow = _root.querySelector(".arrow");
+                var bar = _root.querySelector(".bar");
+                if (bar != null) {
+                    var barLength = bar.x2.baseVal.value - bar.x1.baseVal.value;
+                    this.valueToArrowX = (barLength * 0.5) / this.maxValue;
+                }
+            }
+            this.refreshValue(0, true);
+        }
+        update(_deltaTime) {
+            this.refreshValue(SimVar.GetSimVarValue("RUDDER TRIM", "degrees"));
+        }
+        refreshValue(_value, _force = false) {
+            if ((_value != this.currentValue) || _force) {
+                this.currentValue = Utils.Clamp(_value, -this.maxValue, this.maxValue);
+                var bShowLeft = false;
+                var bShowRight = false;
+                var displayValue = Math.abs(this.currentValue);
+                if (displayValue <= 0.05) {
+                    displayValue = 0;
+                }
+                else {
+                    bShowLeft = (this.currentValue < 0);
+                    bShowRight = !bShowLeft;
+                }
+                if (this.valueText != null) {
+                    this.valueText.textContent = displayValue.toFixed(1);
+                }
+                if (this.leftText != null) {
+                    this.leftText.style.display = bShowLeft ? "block" : "none";
+                }
+                if (this.rightText != null) {
+                    this.rightText.style.display = bShowRight ? "block" : "none";
+                }
+                if (this.arrow != null) {
+                    var arrowX = this.currentValue * this.valueToArrowX;
+                    this.arrow.setAttribute("transform", "translate(" + arrowX + ",0)");
+                }
+            }
+        }
+    }
+    Boeing.RudderDisplay = RudderDisplay;
+    class FuelBaseComponent {
+        constructor(_element, _index) {
+            this.element = null;
+            this.index = 0;
+            this.element = _element;
+            this.index = _index;
+        }
+    }
+    Boeing.FuelBaseComponent = FuelBaseComponent;
+    class FuelEngineState extends FuelBaseComponent {
+        constructor() {
+            super(...arguments);
+            this.isActive = false;
+        }
+        init() {
+            this.refresh(false, true);
+        }
+        update(_deltaTime) {
+            this.refresh(SimVar.GetSimVarValue("ENG FUEL FLOW GPH:" + this.index, "gallons per hour") > 0.05);
+        }
+        refresh(_isActive, _force = false) {
+            if (_force || (this.isActive != _isActive)) {
+                this.isActive = _isActive;
+                if (this.element != null) {
+                    var className = this.isActive ? "active" : "inactive";
+                    this.element.setAttribute("class", "fuelengine-" + className);
+                }
+            }
+        }
+    }
+    Boeing.FuelEngineState = FuelEngineState;
+    class FuelPump extends FuelBaseComponent {
+        constructor() {
+            super(...arguments);
+            this.isSwitched = false;
+            this.isActive = false;
+        }
+        init() {
+            this.refresh(false, false, true);
+        }
+        update(_deltaTime) {
+            this.refresh(SimVar.GetSimVarValue("FUELSYSTEM PUMP SWITCH:" + this.index, "Bool"), SimVar.GetSimVarValue("FUELSYSTEM PUMP ACTIVE:" + this.index, "Bool"));
+        }
+        refresh(_isSwitched, _isActive, _force = false) {
+            if (_force || (this.isSwitched != _isSwitched) || (this.isActive != _isActive)) {
+                this.isSwitched = _isSwitched;
+                this.isActive = _isActive;
+                if (this.element != null) {
+                    var className = this.isSwitched ? "switched" : "notswitched";
+                    className += this.isActive ? "-active" : "-inactive";
+                    this.element.setAttribute("class", "fuelpump-" + className);
+                }
+            }
+        }
+    }
+    Boeing.FuelPump = FuelPump;
+    class FuelValve extends FuelBaseComponent {
+        constructor() {
+            super(...arguments);
+            this.isSwitched = false;
+            this.isOpen = false;
+            this.transformStringClosed = "";
+            this.transformStringOpen = "";
+        }
+        init() {
+            if (this.element != null) {
+                var baseTransform = this.element.getAttribute("transform");
+                var rotateIndex = baseTransform.search("rotate");
+                if (rotateIndex < 0) {
+                    this.transformStringClosed = baseTransform + " rotate(0)";
+                    this.transformStringOpen = baseTransform + " rotate(90)";
+                }
+                else {
+                    this.transformStringClosed = baseTransform;
+                    var rotateStartIndex = baseTransform.indexOf("rotate(") + 7;
+                    var rotateEndIndex = baseTransform.indexOf(")", rotateStartIndex);
+                    var angle = parseFloat(baseTransform.slice(rotateStartIndex, rotateEndIndex));
+                    this.transformStringOpen = baseTransform.replace("rotate(" + angle + ")", "rotate(" + (angle + 90) + ")");
+                }
+            }
+            this.refresh(false, 0, true);
+        }
+        update(_deltaTime) {
+            this.refresh(SimVar.GetSimVarValue("FUELSYSTEM VALVE SWITCH:" + this.index, "Bool"), SimVar.GetSimVarValue("FUELSYSTEM VALVE OPEN:" + this.index, "number"));
+        }
+        refresh(_isSwitched, _openLevel, _force = false) {
+            var open = this.isOpen;
+            if (_openLevel >= 1) {
+                open = true;
+            }
+            else if (_openLevel <= 0) {
+                open = false;
+            }
+            if (_force || (this.isSwitched != _isSwitched) || (this.isOpen != open)) {
+                this.isSwitched = _isSwitched;
+                this.isOpen = open;
+                if (this.element != null) {
+                    if (this.isSwitched || this.isOpen) {
+                        this.element.setAttribute("class", this.isSwitched ? "fuelvalve-open" : "fuelvalve-closing");
+                        this.element.setAttribute("transform", this.transformStringOpen);
+                    }
+                    else {
+                        this.element.setAttribute("class", "fuelvalve-closed");
+                        this.element.setAttribute("transform", this.transformStringClosed);
+                    }
+                }
+            }
+        }
+    }
+    Boeing.FuelValve = FuelValve;
+    class FuelLine extends FuelBaseComponent {
+        constructor() {
+            super(...arguments);
+            this.isActive = false;
+        }
+        init() {
+            this.refresh(false, true);
+        }
+        update(_deltaTime) {
+            this.refresh(SimVar.GetSimVarValue("FUELSYSTEM LINE FUEL FLOW:" + this.index, "number") > 0);
+        }
+        refresh(_isActive, _force = false) {
+            if (_force || (this.isActive != _isActive)) {
+                this.isActive = _isActive;
+                if (this.element != null) {
+                    var className = this.isActive ? "active" : "inactive";
+                    this.element.setAttribute("class", "fuelline-" + className);
+                }
+            }
+        }
+    }
+    Boeing.FuelLine = FuelLine;
+    class InfoPanelsManager extends Airliners.EICASInfoPanelManager {
+        init(_panel) {
+            this.mainPanel = _panel;
+            Coherent.on("AddUpperECAMMessage", this.onInfoPanelEvent.bind(this, Airliners.EICAS_INFO_PANEL_EVENT_TYPE.ADD_MESSAGE));
+            Coherent.on("RemoveUpperECAMMessage", this.onInfoPanelEvent.bind(this, Airliners.EICAS_INFO_PANEL_EVENT_TYPE.REMOVE_MESSAGE));
+            Coherent.on("ModifyUpperECAMMessage", this.onInfoPanelEvent.bind(this, Airliners.EICAS_INFO_PANEL_EVENT_TYPE.MODIFY_MESSAGE));
+            Coherent.on("ClearUpperECAMScreen", this.onInfoPanelEvent.bind(this, Airliners.EICAS_INFO_PANEL_EVENT_TYPE.CLEAR_SCREEN));
+        }
+        addMessage(_id, _message, _style) {
+            if (_message != "") {
+                let infoPanel = this.getInfoPanel(_id);
+                if (infoPanel) {
+                    infoPanel.addMessage(_message, _style);
+                }
+            }
+        }
+        removeMessage(_id, _message) {
+            if (_message != "") {
+                let infoPanel = this.getInfoPanel(_id);
+                if (infoPanel) {
+                    infoPanel.removeMessage(_message);
+                }
+            }
+        }
+        modifyMessage(_id, _currentMessage, _newMessage, _newStyle) {
+            let infoPanel = this.getInfoPanel(_id);
+            if (infoPanel) {
+                if (_newMessage == "")
+                    _newMessage = _currentMessage;
+                infoPanel.modifyMessage(_currentMessage, _newMessage, _newStyle);
+            }
+        }
+        clearScreen(_id) {
+            let infoPanel = this.getInfoPanel(_id);
+            if (infoPanel) {
+                infoPanel.clearScreen();
+            }
+        }
+        getInfoPanel(_id) {
+            switch (_id) {
+                case Airliners.EICAS_INFO_PANEL_ID.PRIMARY:
+                    return this.mainPanel;
+                default:
+                    return null;
+            }
+        }
+        onInfoPanelEvent(_type, ..._args) {
+            if ((_args != null) && (_args.length > 0)) {
+                var strings = _args[0];
+                if ((strings != null) && (strings.length > 0)) {
+                    let panelId;
+                    if (strings[0] == "primary") {
+                        panelId = Airliners.EICAS_INFO_PANEL_ID.PRIMARY;
+                    }
+                    else if (strings[0] == "secondary") {
+                        panelId = Airliners.EICAS_INFO_PANEL_ID.PRIMARY;
+                    }
+                    else {
+                        return;
+                    }
+                    switch (_type) {
+                        case Airliners.EICAS_INFO_PANEL_EVENT_TYPE.ADD_MESSAGE:
+                            {
+                                if (strings.length >= 3) {
+                                    this.addMessage(panelId, strings[1], Airliners.EICAS_INFO_PANEL_MESSAGE_STYLE[strings[2]]);
+                                }
+                                break;
+                            }
+                        case Airliners.EICAS_INFO_PANEL_EVENT_TYPE.REMOVE_MESSAGE:
+                            {
+                                if (strings.length >= 2) {
+                                    this.removeMessage(panelId, strings[1]);
+                                }
+                                break;
+                            }
+                        case Airliners.EICAS_INFO_PANEL_EVENT_TYPE.MODIFY_MESSAGE:
+                            {
+                                if (strings.length >= 4) {
+                                    this.modifyMessage(panelId, strings[1], strings[2], Airliners.EICAS_INFO_PANEL_MESSAGE_STYLE[strings[3]]);
+                                }
+                                break;
+                            }
+                        case Airliners.EICAS_INFO_PANEL_EVENT_TYPE.CLEAR_SCREEN:
+                            {
+                                this.clearScreen(panelId);
+                                break;
+                            }
+                    }
+                }
+            }
+        }
+    }
+    Boeing.InfoPanelsManager = InfoPanelsManager;
+    class InfoPanel {
+        constructor(_parent, _divID) {
+            this.allDivs = [];
+            this.parent = _parent;
+            this.divID = _divID;
+        }
+        init() {
+            this.create();
+        }
+        update(_deltaTime) {
+        }
+        create() {
+            if (this.parent != null) {
+                this.divMain = this.createDiv(this.divID);
+                this.parent.appendChild(this.divMain);
+            }
+        }
+        createDiv(_id, _class = "", _text = "") {
+            var div = document.createElement("div");
+            if (_id.length > 0) {
+                div.id = _id;
+            }
+            if (_class.length > 0) {
+                div.className = _class;
+            }
+            if (_text.length > 0) {
+                div.textContent = _text;
+            }
+            return div;
+        }
+        getNextAvailableDiv() {
+            for (var i = 0; i < this.allDivs.length; ++i) {
+                if (this.allDivs[i].textContent.length == 0) {
+                    return this.allDivs[i];
+                }
+            }
+            if (this.divMain != null) {
+                var newDiv = document.createElement("div");
+                this.allDivs.push(newDiv);
+                this.divMain.appendChild(newDiv);
+                return newDiv;
+            }
+            return null;
+        }
+        getDivFromMessage(_message) {
+            for (var i = 0; i < this.allDivs.length; ++i) {
+                if (this.allDivs[i].textContent == _message) {
+                    return this.allDivs[i];
+                }
+            }
+            return null;
+        }
+        getClassNameFromStyle(_style) {
+            switch (_style) {
+                case Airliners.EICAS_INFO_PANEL_MESSAGE_STYLE.INDICATION: return "InfoIndication";
+                case Airliners.EICAS_INFO_PANEL_MESSAGE_STYLE.CAUTION: return "InfoCaution";
+                case Airliners.EICAS_INFO_PANEL_MESSAGE_STYLE.WARNING: return "InfoWarning";
+            }
+            return "";
+        }
+        addMessage(_message, _style) {
+            var div = this.getNextAvailableDiv();
+            if (div != null) {
+                div.textContent = _message;
+                div.className = this.getClassNameFromStyle(_style);
+            }
+        }
+        removeMessage(_message) {
+            var div = this.getDivFromMessage(_message);
+            if (div != null) {
+                div.textContent = "";
+                for (var i = 0; i < (this.allDivs.length - 1); ++i) {
+                    if (this.allDivs[i].textContent.length == 0) {
+                        if (this.allDivs[i + 1].textContent.length > 0) {
+                            this.allDivs[i].textContent = this.allDivs[i + 1].textContent;
+                            this.allDivs[i].className = this.allDivs[i + 1].className;
+                            this.allDivs[i + 1].textContent = "";
+                        }
+                    }
+                }
+            }
+        }
+        modifyMessage(_currentMessage, _newMessage, _newStyle) {
+            var div = this.getDivFromMessage(_currentMessage);
+            if (div != null) {
+                div.textContent = _newMessage;
+                div.className = this.getClassNameFromStyle(_newStyle);
+            }
+        }
+        clearScreen() {
+            for (var i = 0; i < this.allDivs.length; ++i) {
+                this.allDivs[i].textContent = "";
+            }
+        }
+    }
+    Boeing.InfoPanel = InfoPanel;
+})(Boeing || (Boeing = {}));
+//# sourceMappingURL=Boeing_Common.js.map

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC.html
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC.html
@@ -16,7 +16,7 @@
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/FlightElements/Approach.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/FlightElements/FlightPlan.js"></script>
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/FlightElements/WaypointLoader.js"></script>
-<script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/FlightElements/FlightPlanManager.js"></script>
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FlightPlanManager.js"></script> <!--modified-->
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/FlightElements/GeoCalc.js"></script>
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/NavSystems/Shared/LogicElements/SearchField.js"></script>

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC.html
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC.html
@@ -27,8 +27,8 @@
 <script type="text/html" import-script="/Pages/Salty/SaltyIRS.js"></script>
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/Shared/BaseAirliners.js"></script>
-<script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/Shared/FMC/FMCMainDisplay.js"></script>
-<script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/Shared/Boeing/Boeing_FMC.js"></script>
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js"></script> <!--modified-->
+<script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js"></script> <!--modified-->
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/Shared/FMC/FMCDataManager.js"></script>
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplayDebug.js"></script>

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
@@ -648,19 +648,26 @@ class B747_8_FMC_MainDisplay extends Boeing_FMC {
                         SimVar.SetSimVarValue("L:AIRLINER_FMS_SHOW_TOP_DSCNT", "number", 0);
                     }
                     let selectedAltitude = Simplane.getAutoPilotSelectedAltitudeLockValue("feet");
-                    if (!this.flightPlanManager.getIsDirectTo() &&
-                        isFinite(nextWaypoint.legAltitude1) &&
-                        nextWaypoint.legAltitude1 < 20000 &&
-                        nextWaypoint.legAltitude1 > selectedAltitude &&
-                        Simplane.getAltitude() > nextWaypoint.legAltitude1 - 200) {
-                        Coherent.call("AP_ALT_VAR_SET_ENGLISH", 2, nextWaypoint.legAltitude1, this._forceNextAltitudeUpdate);
-                        this._forceNextAltitudeUpdate = false;
-                        SimVar.SetSimVarValue("L:AP_CURRENT_TARGET_ALTITUDE_IS_CONSTRAINT", "number", 1);
-                    }
+                    if (!this.flightPlanManager.getIsDirectTo() && isFinite(nextWaypoint.legAltitude1) &&
+                        isFinite(selectedAltitude)) {
+                            let currentAlt = Simplane.getAltitude();
+                            let mcpDelta = selectedAltitude - currentAlt;
+                            let constraintDelta = nextWaypoint.legAltitude1 - currentAlt;
+                            if (mcpDelta > constraintDelta) {
+                                Coherent.call("AP_ALT_VAR_SET_ENGLISH", 2, selectedAltitude, this._forceNextAltitudeUpdate);
+                                this._forceNextAltitudeUpdate = false;
+                                SimVar.SetSimVarValue("L:AP_CURRENT_TARGET_ALTITUDE_IS_CONSTRAINT", "number", 0);
+                            } 
+                            else {
+                                Coherent.call("AP_ALT_VAR_SET_ENGLISH", 2, nextWaypoint.legAltitude1, this._forceNextAltitudeUpdate);
+                                this._forceNextAltitudeUpdate = false;
+                                SimVar.SetSimVarValue("L:AP_CURRENT_TARGET_ALTITUDE_IS_CONSTRAINT", "number", 1);
+                            }
+                        }
                     else {
                         let altitude = Simplane.getAutoPilotSelectedAltitudeLockValue("feet");
                         if (isFinite(altitude)) {
-                            Coherent.call("AP_ALT_VAR_SET_ENGLISH", 2, this.cruiseFlightLevel * 100, this._forceNextAltitudeUpdate);
+                            Coherent.call("AP_ALT_VAR_SET_ENGLISH", 2, altitude, this._forceNextAltitudeUpdate);
                             this._forceNextAltitudeUpdate = false;
                             SimVar.SetSimVarValue("L:AP_CURRENT_TARGET_ALTITUDE_IS_CONSTRAINT", "number", 0);
                         }
@@ -669,7 +676,7 @@ class B747_8_FMC_MainDisplay extends Boeing_FMC {
                 else {
                     let altitude = Simplane.getAutoPilotSelectedAltitudeLockValue("feet");
                     if (isFinite(altitude)) {
-                        Coherent.call("AP_ALT_VAR_SET_ENGLISH", 2, this.cruiseFlightLevel * 100, this._forceNextAltitudeUpdate);
+                        Coherent.call("AP_ALT_VAR_SET_ENGLISH", 2, altitude, this._forceNextAltitudeUpdate);
                         this._forceNextAltitudeUpdate = false;
                         SimVar.SetSimVarValue("L:AP_CURRENT_TARGET_ALTITUDE_IS_CONSTRAINT", "number", 0);
                     }

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
@@ -286,7 +286,6 @@ class B747_8_FMC_MainDisplay extends Boeing_FMC {
         let dCI = this.getCostIndexFactor();
         let speed = 310 * (1 - dCI) + 330 * dCI;
         let flapsHandleIndex = Simplane.getFlapsHandleIndex();
-        
         let flapLimitSpeed = Simplane.getFlapsLimitSpeed(this.aircraft, flapsHandleIndex);
         speed = flapLimitSpeed - 5;
         let flapsUPmanueverSpeed = this.getFlapApproachSpeed(true) + 80;
@@ -656,23 +655,56 @@ class B747_8_FMC_MainDisplay extends Boeing_FMC {
                         SimVar.SetSimVarValue("L:AIRLINER_FMS_SHOW_TOP_DSCNT", "number", 0);
                     }             
                 }
-                //Sets autopilot capture altitude to closest of MCP alt or Leg Constraint to allow for VNAV ALT mode.
-                let selectedAltitude = Simplane.getAutoPilotSelectedAltitudeLockValue("feet");
+                //Sets autopilot capture altitude to closest of MCP alt or Leg Constraint/CRZ ALT to allow for VNAV ALT mode.
+                let selectedAltitude = Simplane.getAutoPilotDisplayedAltitudeLockValue("feet");
                 let crzAlt = SimVar.GetSimVarValue("L:AIRLINER_CRUISE_ALTITUDE", "number");
                 if (isFinite(selectedAltitude) && isFinite(nextWaypoint.legAltitude1) && isFinite(crzAlt)) {
                     let currentAlt = Simplane.getAltitude();
-                    let mcpDelta = selectedAltitude - currentAlt;
-                    let constraintDelta = nextWaypoint.legAltitude1 - currentAlt;
-                    let crzAltDelta = crzAlt - currentAlt;
+                    let mcpDelta = Math.abs(selectedAltitude - currentAlt);
+                    let constraintDelta = Math.abs(nextWaypoint.legAltitude1 - currentAlt);
+                    let crzAltDelta = Math.abs(crzAlt - currentAlt);
+                    SimVar.SetSimVarValue("L:MCP", "number", mcpDelta);
+                    SimVar.SetSimVarValue("L:CONSTRAINT", "number", constraintDelta);
+                    SimVar.SetSimVarValue("L:CRZ", "number", crzAltDelta);
+
+                    //MCP Alt is closest
                     if (mcpDelta < constraintDelta && mcpDelta < crzAltDelta) {
                         Coherent.call("AP_ALT_VAR_SET_ENGLISH", 2, selectedAltitude, this._forceNextAltitudeUpdate);
                         this._forceNextAltitudeUpdate = false;
                         SimVar.SetSimVarValue("L:AP_CURRENT_TARGET_ALTITUDE_IS_CONSTRAINT", "number", 0);
                     } 
+                    //Waypoint constraint is closest
                     else if (constraintDelta < crzAltDelta){
-                        Coherent.call("AP_ALT_VAR_SET_ENGLISH", 2, nextWaypoint.legAltitude1, this._forceNextAltitudeUpdate);
-                        this._forceNextAltitudeUpdate = false;
-                        SimVar.SetSimVarValue("L:AP_CURRENT_TARGET_ALTITUDE_IS_CONSTRAINT", "number", 1);
+                        //Set autopilot target to waypoint leg AT constraint
+                        if (nextWaypoint.legAltitudeDescription === 1){
+                            Coherent.call("AP_ALT_VAR_SET_ENGLISH", 2, nextWaypoint.legAltitude1, this._forceNextAltitudeUpdate);
+                            this._forceNextAltitudeUpdate = false;
+                            SimVar.SetSimVarValue("L:AP_CURRENT_TARGET_ALTITUDE_IS_CONSTRAINT", "number", 1);
+                        } 
+                        //Ignore waypoint leg ABOVE constraint while climbing
+                        else if (nextWaypoint.legAltitudeDescription === 2 && ((Simplane.getCurrentFlightPhase() == FlightPhase.FLIGHT_PHASE_TAKEOFF)
+                        || (Simplane.getCurrentFlightPhase() == FlightPhase.FLIGHT_PHASE_CLIMB))) {
+                            
+                        } 
+                        //Set autopilot target to waypoint leg BELOW constraint while climbing
+                        else if (nextWaypoint.legAltitudeDescription === 3 && ((Simplane.getCurrentFlightPhase() == FlightPhase.FLIGHT_PHASE_TAKEOFF)
+                        || (Simplane.getCurrentFlightPhase() == FlightPhase.FLIGHT_PHASE_CLIMB))) {
+                            Coherent.call("AP_ALT_VAR_SET_ENGLISH", 2, nextWaypoint.legAltitude1, this._forceNextAltitudeUpdate);
+                            this._forceNextAltitudeUpdate = false;
+                            SimVar.SetSimVarValue("L:AP_CURRENT_TARGET_ALTITUDE_IS_CONSTRAINT", "number", 1);
+                        } 
+                        //Ignore waypoint leg BELOW constraint while descending
+                        else if (nextWaypoint.legAltitudeDescription === 3 && ((Simplane.getCurrentFlightPhase() == FlightPhase.FLIGHT_PHASE_DESCENT)
+                        || (Simplane.getCurrentFlightPhase() == FlightPhase.FLIGHT_PHASE_APPROACH))) {
+                            
+                        } 
+                        //Set autopilot target to waypoint leg ABOVE constraint while descending
+                        else if (nextWaypoint.legAltitudeDescription === 2 && ((Simplane.getCurrentFlightPhase() == FlightPhase.FLIGHT_PHASE_DESCENT)
+                        || (Simplane.getCurrentFlightPhase() == FlightPhase.FLIGHT_PHASE_APPROACH))) {
+                            Coherent.call("AP_ALT_VAR_SET_ENGLISH", 2, nextWaypoint.legAltitude1, this._forceNextAltitudeUpdate);
+                            this._forceNextAltitudeUpdate = false;
+                            SimVar.SetSimVarValue("L:AP_CURRENT_TARGET_ALTITUDE_IS_CONSTRAINT", "number", 1);
+                        } 
                     }
                     else {
                         Coherent.call("AP_ALT_VAR_SET_ENGLISH", 2, crzAlt, this._forceNextAltitudeUpdate);
@@ -755,15 +787,6 @@ class B747_8_FMC_MainDisplay extends Boeing_FMC {
                 if (this.getIsVNAVActive()) {
                     let speed = this.getCrzManagedSpeed();
                     this.setAPManagedSpeed(speed, Aircraft.B747_8);
-                    let altitude = Simplane.getAltitudeAboveGround();
-                    let n1 = 100;
-                    if (altitude < this.thrustReductionAltitude) {
-                        n1 = this.getThrustTakeOffLimit() / 100;
-                    }
-                    else {
-                        n1 = this.getThrustClimbLimit() / 100;
-                    }
-                    SimVar.SetSimVarValue("AUTOPILOT THROTTLE MAX THRUST", "number", n1);
                 }
             }
             else if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_DESCENT) {

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
@@ -736,7 +736,7 @@ class B747_8_FMC_MainDisplay extends Boeing_FMC {
                     let thrRedAlt = SimVar.GetSimVarValue("L:AIRLINER_THR_RED_ALT", "number");
                     let n1 = 100;
                     let thrDerate = 0;
-                    if (agl > 1500) {
+                    if (agl > thrRedAlt) {
                         n1 = this.getThrustClimbLimit() / 100;
                         SimVar.SetSimVarValue("AUTOPILOT THROTTLE MAX THRUST", "number", n1);
                         this.setThrottleMode(ThrottleMode.CLIMB);

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
@@ -648,6 +648,7 @@ class B747_8_FMC_MainDisplay extends Boeing_FMC {
                         SimVar.SetSimVarValue("L:AIRLINER_FMS_SHOW_TOP_DSCNT", "number", 0);
                     }
                     let selectedAltitude = Simplane.getAutoPilotSelectedAltitudeLockValue("feet");
+                    //Sets autopilot capture altitude to closest of MCP alt or Leg Constraint to allow for VNAV ALT mode
                     if (!this.flightPlanManager.getIsDirectTo() && isFinite(nextWaypoint.legAltitude1) &&
                         isFinite(selectedAltitude)) {
                             let currentAlt = Simplane.getAltitude();
@@ -730,6 +731,16 @@ class B747_8_FMC_MainDisplay extends Boeing_FMC {
                 if (this.getIsVNAVActive()) {
                     let speed = this.getTakeOffManagedSpeed();
                     this.setAPManagedSpeed(speed, Aircraft.B747_8);
+                    //Sets CLB Thrust when passing thrust reduction altitude
+                    let agl = Simplane.getAltitudeAboveGround();
+                    let thrRedAlt = SimVar.GetSimVarValue("L:AIRLINER_THR_RED_ALT", "number");
+                    let n1 = 100;
+                    let thrDerate = 0;
+                    if (agl > 1500) {
+                        n1 = this.getThrustClimbLimit() / 100;
+                        SimVar.SetSimVarValue("AUTOPILOT THROTTLE MAX THRUST", "number", n1);
+                        this.setThrottleMode(ThrottleMode.CLIMB);
+                    }
                 }
             }
             else if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_CLIMB) {
@@ -744,6 +755,7 @@ class B747_8_FMC_MainDisplay extends Boeing_FMC {
                     else {
                         n1 = this.getThrustClimbLimit() / 100;
                     }
+                    
                     SimVar.SetSimVarValue("AUTOPILOT THROTTLE MAX THRUST", "number", n1);
                 }
             }

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
@@ -681,6 +681,10 @@ class B747_8_FMC_MainDisplay extends Boeing_FMC {
                         SimVar.SetSimVarValue("L:AP_CURRENT_TARGET_ALTITUDE_IS_CONSTRAINT", "number", 0);
                     }
                 }
+                //Triggers correct Autothrottle mode SPD when capturing in VNAV
+                if (Simplane.getAutoPilotAltitudeLockActive() && Simplane.getAutoPilotThrottleArmed()) {
+                    this.activateSPD();
+                }
             }
             else if (!this.getIsFLCHActive() && this.getIsSPDActive()) {
                 this.setAPSpeedHoldMode();

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
@@ -624,6 +624,10 @@ class B747_8_FMC_MainDisplay extends Boeing_FMC {
             if (this.getIsVNAVActive()) {
                 let prevWaypoint = this.flightPlanManager.getPreviousActiveWaypoint();
                 let nextWaypoint = this.flightPlanManager.getActiveWaypoint();
+                if (nextWaypoint && SimVar.GetSimVarValue("L:ALT_SEL_PUSHED", "bool")) {
+                    nextWaypoint.legAltitudeDescription = 0;
+                    SimVar.SetSimVarValue("L:ALT_SEL_PUSHED", "bool", 0);
+                }
                 if (nextWaypoint && (nextWaypoint.legAltitudeDescription === 3 || nextWaypoint.legAltitudeDescription === 4)) {
                     let targetAltitude = nextWaypoint.legAltitude1;
                     if (nextWaypoint.legAltitudeDescription === 4) {
@@ -661,12 +665,15 @@ class B747_8_FMC_MainDisplay extends Boeing_FMC {
                 if (isFinite(selectedAltitude) && isFinite(nextWaypoint.legAltitude1) && isFinite(crzAlt)) {
                     let currentAlt = Simplane.getAltitude();
                     let mcpDelta = Math.abs(selectedAltitude - currentAlt);
-                    let constraintDelta = Math.abs(nextWaypoint.legAltitude1 - currentAlt);
+                    let constraintDelta = 100000;
+                    //not a constraint if no description specified
+                    if (nextWaypoint.legAltitudeDescription !== 0) {
+                        constraintDelta = Math.abs(nextWaypoint.legAltitude1 - currentAlt);
+                    }
                     let crzAltDelta = Math.abs(crzAlt - currentAlt);
                     SimVar.SetSimVarValue("L:MCP", "number", mcpDelta);
                     SimVar.SetSimVarValue("L:CONSTRAINT", "number", constraintDelta);
                     SimVar.SetSimVarValue("L:CRZ", "number", crzAltDelta);
-
                     //MCP Alt is closest
                     if (mcpDelta < constraintDelta && mcpDelta < crzAltDelta) {
                         Coherent.call("AP_ALT_VAR_SET_ENGLISH", 2, selectedAltitude, this._forceNextAltitudeUpdate);

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_VNAVPage.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_VNAVPage.js
@@ -19,32 +19,34 @@ class B747_8_FMC_VNAVPage {
                 B747_8_FMC_VNAVPage.ShowPage1(fmc);
             }
         };
+        let clbSpeedCell = ""
+        clbSpeedCell = fmc.getClbManagedSpeed().toFixed(0);
         let speedTransCell = "---";
-        let speed = fmc.getCrzManagedSpeed();
-        if (isFinite(speed)) {
-            speedTransCell = speed.toFixed(0);
+        let flapsUPmanueverSpeed = fmc.getFlapApproachSpeed(true) + 80;
+        let transSpeed = Math.max(flapsUPmanueverSpeed + 20, 250);
+        if (isFinite(transSpeed)) {
+            speedTransCell = transSpeed.toFixed(0);
+            speedTransCell += "/10000";
         }
-        speedTransCell += "/";
+        let transAltCell = "";
         if (isFinite(fmc.transitionAltitude)) {
-            speedTransCell += fmc.transitionAltitude.toFixed(0);
+            transAltCell = fmc.transitionAltitude.toFixed(0);
         }
-        else {
-            speedTransCell += "-----";
-        }
+        let maxAngleCell = (flapsUPmanueverSpeed + 20).toFixed(0);
         fmc.setTemplate([
-            ["CLB", "1", "3"],
-            ["CRZ ALT"],
+            ["ACT ECON CLB", "1", "3"],
+            ["\xa0CRZ ALT"],
             [crzAltCell],
-            ["ECON SPD"],
+            ["\xa0ECON SPD"],
+            [clbSpeedCell],
+            ["\xa0SPD TRANS", "TRANS ALT"],
+            [speedTransCell, transAltCell],
+            ["\xa0SPD RESTR", "MAX ANGLE"],
+            ["---/-----", maxAngleCell],
+            ["__FMCSEPARATOR"],
+            ["<ECON", "ENG OUT>"],
             [],
-            ["SPD TRANS", "TRANS ALT"],
-            [speedTransCell],
-            ["SPD RESTR"],
-            [],
-            [],
-            ["", "<ENG OUT"],
-            [],
-            []
+            ["", "CLB DIR>"]
         ]);
         fmc.onNextPage = () => { B747_8_FMC_VNAVPage.ShowPage2(fmc); };
     }
@@ -58,10 +60,10 @@ class B747_8_FMC_VNAVPage {
             }
         };        
         let crzPageTitle = "ACT ECON CRZ"
-        let crzSpeedMode = "ECON SPD"
+        let crzSpeedMode = "\xa0ECON SPD"
         if (SimVar.GetSimVarValue("L:AP_SPEED_INTERVENTION_ACTIVE", "number") == 1) {
             crzPageTitle = "ACT MCP SPD CRZ"
-            crzSpeedMode = "SEL SPD"
+            crzSpeedMode = "\xa0SEL SPD"
         }
         let crzSpeedCell = ""
         let machMode = Simplane.getAutoPilotMachModeActive();
@@ -96,13 +98,13 @@ class B747_8_FMC_VNAVPage {
         
         fmc.setTemplate([
             [crzPageTitle, "2", "3"],
-            ["CRZ ALT", "STEP TO"],
+            ["\xa0CRZ ALT", "STEP TO"],
             [crzAltCell],
             [crzSpeedMode, "AT"],
             [crzSpeedCell],
-            ["N1"],
+            ["\xa0N1"],
             [n1Cell],
-            ["STEP", "RECMD", "OPT\xa0\xa0\xa0MAX"],
+            ["\xa0STEP", "RECMD", "OPT\xa0\xa0\xa0MAX"],
             ["RVSM", "", "\xa0\xa0\xa0\xa0\xa0\xa0" + "FL" + maxFltLevel.toFixed(0)],
             ["__FMCSEPARATOR"],
             ["", "ENG OUT>"],

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
@@ -206,7 +206,6 @@ class Boeing_FMC extends FMCMainDisplay {
         SimVar.SetSimVarValue("K:ALTITUDE_SLOT_INDEX_SET", "number", 2);
         if (this.aircraftType == Aircraft.AS01B)
             this.activateSPD();
-        this.setThrottleMode(ThrottleMode.CLIMB);
     }
     setThrottleMode(_mode) {
         if (this.getIsSPDActive() && this.aircraftType == Aircraft.AS01B)
@@ -362,7 +361,12 @@ class Boeing_FMC extends FMCMainDisplay {
     }
     activateTHRREFMode() {
         let altitude = Simplane.getAltitudeAboveGround();
-        this.setThrottleMode(ThrottleMode.CLIMB);
+        if (Simplane.getCurrentFlightPhase() === FlightPhase.FLIGHT_PHASE_TAKEOFF && altitude <= 500) {
+            this.setThrottleMode(ThrottleMode.TOGA);
+            return;
+        } else {
+            this.setThrottleMode(ThrottleMode.CLIMB);
+        }
         let n1 = 100;
         if (altitude < this.thrustReductionAltitude) {
             n1 = this.getThrustTakeOffLimit();
@@ -526,11 +530,11 @@ class Boeing_FMC extends FMCMainDisplay {
         return 200;
     }
     getTakeOffManagedSpeed() {
-        let altitude = Simplane.getAltitudeAboveGround();
-        if (altitude < 3000) {
+        if (this.v2Speed) {
             return this.v2Speed;
         }
-        return 250;
+        let takeoffSpeed = Simplane.getAutoPilotAirspeedHoldValue();
+        return takeoffSpeed;
     }
     getIsRouteActivated() {
         return this._isRouteActivated;

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
@@ -284,9 +284,6 @@ class Boeing_FMC extends FMCMainDisplay {
         }
     }
     activateSPD() {
-        if (this.getIsVNAVActive() && this.aircraftType != Aircraft.AS01B) {
-            return;
-        }
         let altitude = Simplane.getAltitudeAboveGround();
         if (altitude < 400) {
             this._pendingSPDActivation = true;

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
@@ -527,8 +527,8 @@ class Boeing_FMC extends FMCMainDisplay {
     }
     getTakeOffManagedSpeed() {
         let altitude = Simplane.getAltitudeAboveGround();
-        if (altitude < 35) {
-            return this.v2Speed + 15;
+        if (altitude < 3000) {
+            return this.v2Speed;
         }
         return 250;
     }

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
@@ -101,6 +101,7 @@ class Boeing_FMC extends FMCMainDisplay {
         }
         else if (_event.indexOf("AP_ALT_INTERVENTION") != -1) {
             this.activateAltitudeSel();
+            SimVar.SetSimVarValue("L:ALT_SEL_PUSHED", "bool", 1);
         }
         else if (_event.indexOf("AP_ALT_HOLD") != -1) {
             this.toggleAltitudeHold();

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
@@ -1,0 +1,579 @@
+class Boeing_FMC extends FMCMainDisplay {
+    constructor() {
+        super(...arguments);
+        this._forceNextAltitudeUpdate = false;
+        this._lastTargetAirspeed = 200;
+        this._isLNAVActive = false;
+        this._pendingLNAVActivation = false;
+        this._isVNAVActive = false;
+        this._pendingVNAVActivation = false;
+        this._isFLCHActive = false;
+        this._pendingFLCHActivation = false;
+        this._isSPDActive = false;
+        this._pendingSPDActivation = false;
+        this._isSpeedInterventionActive = false;
+        this._isHeadingHoldActive = false;
+        this._headingHoldValue = 0;
+        this._pendingHeadingSelActivation = false;
+        this._isVSpeedActive = false;
+        this._isAltitudeHoldActive = false;
+        this._altitudeHoldValue = 0;
+        this._onAltitudeHoldDeactivate = EmptyCallback.Void;
+        this._isRouteActivated = false;
+    }
+    Init() {
+        super.Init();
+        this.maxCruiseFL = 450;
+        this.cruiseFlightLevel = 100;
+        this.onExec = () => {
+            if (this.getIsRouteActivated()) {
+                this.insertTemporaryFlightPlan();
+                this._isRouteActivated = false;
+                SimVar.SetSimVarValue("L:FMC_EXEC_ACTIVE", "number", 0);
+                if (this.refreshPageCallback) {
+                    this.refreshPageCallback();
+                }
+            }
+        };
+        this.onDel = () => {
+            if (this.inOut.length === 0) {
+                this.inOut = "DELETE";
+            }
+        };
+        this.onClr = () => {
+            if (this.isDisplayingErrorMessage) {
+                this.inOut = this.lastUserInput;
+                this.isDisplayingErrorMessage = false;
+            }
+            else if (this.inOut.length > 0) {
+                if (this.inOut === "DELETE") {
+                    this.inOut = "";
+                }
+                else {
+                    this.inOut = this.inOut.substr(0, this.inOut.length - 1);
+                }
+            }
+        };
+        let flapAngles = [0, 1, 5, 10, 15, 17, 18, 20, 25, 30];
+        let flapIndex = Simplane.getFlapsHandleIndex(true);
+        if (flapIndex >= 1) {
+            this._takeOffFlap = flapAngles[flapIndex];
+        }
+    }
+    onEvent(_event) {
+        super.onEvent(_event);
+        console.log("B747_8_FMC_MainDisplay onEvent " + _event);
+        if (_event.indexOf("AP_LNAV") != -1) {
+            this.toggleLNAV();
+        }
+        else if (_event.indexOf("AP_VNAV") != -1) {
+            this.toggleVNAV();
+        }
+        else if (_event.indexOf("AP_FLCH") != -1) {
+            this.toggleFLCH();
+        }
+        else if (_event.indexOf("AP_HEADING_HOLD") != -1) {
+            this.toggleHeadingHold();
+        }
+        else if (_event.indexOf("AP_HEADING_SEL") != -1) {
+            this.activateHeadingSel();
+        }
+        else if (_event.indexOf("AP_SPD") != -1) {
+            if (this.aircraftType === Aircraft.AS01B) {
+                if (SimVar.GetSimVarValue("AUTOPILOT THROTTLE ARM", "Bool")) {
+                    this.activateSPD();
+                }
+                else {
+                    this.deactivateSPD();
+                }
+            }
+            else {
+                if ((this.getIsAltitudeHoldActive() || this.getIsVSpeedActive()) && this.getIsTHRActive()) {
+                    this.toggleSPD();
+                }
+            }
+        }
+        else if (_event.indexOf("AP_SPEED_INTERVENTION") != -1) {
+            this.toggleSpeedIntervention();
+        }
+        else if (_event.indexOf("AP_VSPEED") != -1) {
+            this.toggleVSpeed();
+        }
+        else if (_event.indexOf("AP_ALT_INTERVENTION") != -1) {
+            this.activateAltitudeSel();
+        }
+        else if (_event.indexOf("AP_ALT_HOLD") != -1) {
+            this.toggleAltitudeHold();
+        }
+        else if (_event.indexOf("THROTTLE_TO_GA") != -1) {
+            this.setAPSpeedHoldMode();
+            if (this.aircraftType == Aircraft.AS01B)
+                this.deactivateSPD();
+            this.setThrottleMode(ThrottleMode.TOGA);
+            if (Simplane.getIndicatedSpeed() > 80) {
+                this.deactivateLNAV();
+                this.deactivateVNAV();
+            }
+        }
+        else if (_event.indexOf("EXEC") != -1) {
+            this.onExec();
+        }
+    }
+    getIsLNAVArmed() {
+        return this._pendingLNAVActivation;
+    }
+    getIsLNAVActive() {
+        return this._isLNAVActive;
+    }
+    toggleLNAV() {
+        if (this.getIsLNAVArmed()) {
+            this.deactivateLNAV();
+        }
+        else {
+            this.activateLNAV();
+        }
+    }
+    activateLNAV() {
+        if (this.flightPlanManager.getWaypointsCount() === 0) {
+            return;
+        }
+        SimVar.SetSimVarValue("L:AP_LNAV_ARMED", "number", 1);
+        let altitude = Simplane.getAltitudeAboveGround();
+        if (altitude < 50) {
+            this._pendingLNAVActivation = true;
+        }
+        else {
+            this.doActivateLNAV();
+        }
+        this.deactivateHeadingHold();
+    }
+    doActivateLNAV() {
+        this._isLNAVActive = true;
+        this._pendingLNAVActivation = false;
+        if (SimVar.GetSimVarValue("AUTOPILOT APPROACH HOLD", "boolean")) {
+            return;
+        }
+        SimVar.SetSimVarValue("L:AP_LNAV_ACTIVE", "number", 1);
+        SimVar.SetSimVarValue("K:AP_NAV1_HOLD_ON", "number", 1);
+    }
+    deactivateLNAV() {
+        this._pendingLNAVActivation = false;
+        this._isLNAVActive = false;
+        SimVar.SetSimVarValue("L:AP_LNAV_ARMED", "number", 0);
+        SimVar.SetSimVarValue("L:AP_LNAV_ACTIVE", "number", 0);
+    }
+    getIsVNAVArmed() {
+        return this._pendingVNAVActivation;
+    }
+    getIsVNAVActive() {
+        return this._isVNAVActive;
+    }
+    toggleVNAV() {
+        if (this.getIsVNAVArmed()) {
+            this.deactivateVNAV();
+            SimVar.SetSimVarValue("K:ALTITUDE_SLOT_INDEX_SET", "number", 1);
+            SimVar.SetSimVarValue("K:SPEED_SLOT_INDEX_SET", "number", 1);
+        }
+        else {
+            this.activateVNAV();
+        }
+    }
+    activateVNAV() {
+        if (this.flightPlanManager.getWaypointsCount() === 0) {
+            return;
+        }
+        SimVar.SetSimVarValue("L:AP_VNAV_ARMED", "number", 1);
+        let altitude = Simplane.getAltitudeAboveGround();
+        if (altitude < 400) {
+            this._pendingVNAVActivation = true;
+        }
+        else {
+            this.doActivateVNAV();
+        }
+        this.deactivateAltitudeHold();
+        this.deactivateFLCH();
+        this.deactivateVSpeed();
+        if (this.aircraftType != Aircraft.AS01B)
+            this.deactivateSPD();
+    }
+    doActivateVNAV() {
+        this._isVNAVActive = true;
+        SimVar.SetSimVarValue("L:AP_VNAV_ACTIVE", "number", 1);
+        SimVar.SetSimVarValue("K:FLIGHT_LEVEL_CHANGE_ON", "Number", 1);
+        this._pendingVNAVActivation = false;
+        this.activateTHRREFMode();
+        SimVar.SetSimVarValue("K:SPEED_SLOT_INDEX_SET", "number", 2);
+        SimVar.SetSimVarValue("K:ALTITUDE_SLOT_INDEX_SET", "number", 2);
+        if (this.aircraftType == Aircraft.AS01B)
+            this.activateSPD();
+        this.setThrottleMode(ThrottleMode.CLIMB);
+    }
+    setThrottleMode(_mode) {
+        if (this.getIsSPDActive() && this.aircraftType == Aircraft.AS01B)
+            Coherent.call("GENERAL_ENG_THROTTLE_MANAGED_MODE_SET", ThrottleMode.AUTO);
+        else
+            Coherent.call("GENERAL_ENG_THROTTLE_MANAGED_MODE_SET", _mode);
+    }
+    deactivateVNAV() {
+        this._pendingVNAVActivation = false;
+        this._isVNAVActive = false;
+        this._pendingVNAVActivation = false;
+        SimVar.SetSimVarValue("L:AP_VNAV_ARMED", "number", 0);
+        SimVar.SetSimVarValue("L:AP_VNAV_ACTIVE", "number", 0);
+        this.deactivateSpeedIntervention();
+    }
+    getIsFLCHArmed() {
+        return this._pendingFLCHActivation;
+    }
+    getIsFLCHActive() {
+        return this._isFLCHActive;
+    }
+    toggleFLCH() {
+        if (this.getIsFLCHArmed()) {
+            this.deactivateFLCH();
+        }
+        else {
+            this.activateFLCH();
+        }
+    }
+    activateFLCH() {
+        this._isFLCHActive = true;
+        SimVar.SetSimVarValue("L:AP_FLCH_ACTIVE", "number", 1);
+        this.deactivateVNAV();
+        this.deactivateAltitudeHold();
+        this.deactivateVSpeed();
+        let altitude = Simplane.getAltitudeAboveGround();
+        if (altitude < 400) {
+            this._pendingFLCHActivation = true;
+        }
+        else {
+            this.doActivateFLCH();
+        }
+    }
+    doActivateFLCH() {
+        this._pendingFLCHActivation = false;
+        SimVar.SetSimVarValue("K:ALTITUDE_SLOT_INDEX_SET", "number", 1);
+        let displayedAltitude = Simplane.getAutoPilotDisplayedAltitudeLockValue();
+        Coherent.call("AP_ALT_VAR_SET_ENGLISH", 1, displayedAltitude, this._forceNextAltitudeUpdate);
+        if (!Simplane.getAutoPilotFLCActive()) {
+            SimVar.SetSimVarValue("K:FLIGHT_LEVEL_CHANGE_ON", "Number", 1);
+        }
+        SimVar.SetSimVarValue("K:SPEED_SLOT_INDEX_SET", "number", 1);
+        this.setThrottleMode(ThrottleMode.CLIMB);
+        if (this.aircraftType != Aircraft.AS01B) {
+            this.activateSPD();
+        }
+    }
+    deactivateFLCH() {
+        this._isFLCHActive = false;
+        this._pendingFLCHActivation = false;
+        SimVar.SetSimVarValue("L:AP_FLCH_ACTIVE", "number", 0);
+        this.deactivateSpeedIntervention();
+    }
+    getIsSPDArmed() {
+        return this._pendingSPDActivation;
+    }
+    getIsSPDActive() {
+        return this._isSPDActive;
+    }
+    toggleSPD() {
+        if (this.getIsSPDArmed()) {
+            this.deactivateSPD();
+        }
+        else {
+            this.activateSPD();
+        }
+    }
+    activateSPD() {
+        if (this.getIsVNAVActive() && this.aircraftType != Aircraft.AS01B) {
+            return;
+        }
+        let altitude = Simplane.getAltitudeAboveGround();
+        if (altitude < 400) {
+            this._pendingSPDActivation = true;
+        }
+        else {
+            this.doActivateSPD();
+        }
+        SimVar.SetSimVarValue("L:AP_SPD_ACTIVE", "number", 1);
+        this._isSPDActive = true;
+    }
+    doActivateSPD() {
+        this._pendingSPDActivation = false;
+        if (Simplane.getAutoPilotMachModeActive()) {
+            let currentMach = Simplane.getAutoPilotMachHoldValue();
+            Coherent.call("AP_MACH_VAR_SET", 1, currentMach);
+            SimVar.SetSimVarValue("K:AP_MANAGED_SPEED_IN_MACH_ON", "number", 1);
+        }
+        else {
+            let currentSpeed = Simplane.getAutoPilotAirspeedHoldValue();
+            Coherent.call("AP_SPD_VAR_SET", 1, currentSpeed);
+            SimVar.SetSimVarValue("K:AP_MANAGED_SPEED_IN_MACH_OFF", "number", 1);
+        }
+        if (!this._isFLCHActive) {
+            this.setAPSpeedHoldMode();
+        }
+        this.setThrottleMode(ThrottleMode.AUTO);
+        let stayManagedSpeed = (this._pendingVNAVActivation || this._isVNAVActive) && !this._isSpeedInterventionActive;
+        if (!stayManagedSpeed) {
+            SimVar.SetSimVarValue("K:SPEED_SLOT_INDEX_SET", "number", 1);
+        }
+    }
+    deactivateSPD() {
+        SimVar.SetSimVarValue("L:AP_SPD_ACTIVE", "number", 0);
+        this._isSPDActive = false;
+        this._pendingSPDActivation = false;
+    }
+    getIsSpeedInterventionActive() {
+        return this._isSpeedInterventionActive;
+    }
+    toggleSpeedIntervention() {
+        if (this.getIsSpeedInterventionActive()) {
+            this.deactivateSpeedIntervention();
+        }
+        else {
+            this.activateSpeedIntervention();
+        }
+    }
+    activateSpeedIntervention() {
+        if (!this.getIsVNAVActive()) {
+            return;
+        }
+        this._isSpeedInterventionActive = true;
+        if (Simplane.getAutoPilotMachModeActive()) {
+            let currentMach = Simplane.getAutoPilotMachHoldValue();
+            Coherent.call("AP_MACH_VAR_SET", 1, currentMach);
+        }
+        else {
+            let currentSpeed = Simplane.getAutoPilotAirspeedHoldValue();
+            Coherent.call("AP_SPD_VAR_SET", 1, currentSpeed);
+        }
+        SimVar.SetSimVarValue("L:AP_SPEED_INTERVENTION_ACTIVE", "number", 1);
+        SimVar.SetSimVarValue("K:SPEED_SLOT_INDEX_SET", "number", 1);
+        if (this.aircraftType == Aircraft.AS01B)
+            this.activateSPD();
+    }
+    deactivateSpeedIntervention() {
+        this._isSpeedInterventionActive = false;
+        SimVar.SetSimVarValue("L:AP_SPEED_INTERVENTION_ACTIVE", "number", 0);
+        if (this.getIsVNAVActive()) {
+            SimVar.SetSimVarValue("K:SPEED_SLOT_INDEX_SET", "number", 2);
+        }
+    }
+    activateTHRREFMode() {
+        let altitude = Simplane.getAltitudeAboveGround();
+        this.setThrottleMode(ThrottleMode.CLIMB);
+        let n1 = 100;
+        if (altitude < this.thrustReductionAltitude) {
+            n1 = this.getThrustTakeOffLimit();
+        }
+        else {
+            n1 = this.getThrustClimbLimit();
+        }
+        SimVar.SetSimVarValue("AUTOPILOT THROTTLE MAX THRUST", "number", n1);
+    }
+    getIsHeadingHoldActive() {
+        return this._isHeadingHoldActive;
+    }
+    toggleHeadingHold() {
+        if (this.getIsHeadingHoldActive()) {
+            let altitude = Simplane.getAltitudeAboveGround();
+            if (altitude < 50) {
+                this.deactivateHeadingHold();
+            }
+            else {
+                this.activateHeadingHold();
+            }
+        }
+        else {
+            this.activateHeadingHold();
+        }
+    }
+    activateHeadingHold() {
+        this.deactivateLNAV();
+        this._isHeadingHoldActive = true;
+        if (!SimVar.GetSimVarValue("AUTOPILOT HEADING LOCK", "Boolean")) {
+            SimVar.SetSimVarValue("K:AP_PANEL_HEADING_HOLD", "Number", 1);
+        }
+        SimVar.SetSimVarValue("L:AP_HEADING_HOLD_ACTIVE", "number", 1);
+        this._headingHoldValue = Simplane.getHeadingMagnetic();
+        SimVar.SetSimVarValue("K:HEADING_SLOT_INDEX_SET", "number", 2);
+        Coherent.call("HEADING_BUG_SET", 2, this._headingHoldValue);
+    }
+    deactivateHeadingHold() {
+        this._isHeadingHoldActive = false;
+        SimVar.SetSimVarValue("L:AP_HEADING_HOLD_ACTIVE", "number", 0);
+    }
+    activateHeadingSel() {
+        this.deactivateHeadingHold();
+        this.deactivateLNAV();
+        SimVar.SetSimVarValue("K:HEADING_SLOT_INDEX_SET", "number", 1);
+        let altitude = Simplane.getAltitudeAboveGround();
+        if (altitude < 400) {
+            this._pendingHeadingSelActivation = true;
+        }
+        else {
+            this.doActivateHeadingSel();
+        }
+    }
+    doActivateHeadingSel() {
+        this._pendingHeadingSelActivation = false;
+        if (!SimVar.GetSimVarValue("AUTOPILOT HEADING LOCK", "Boolean")) {
+            SimVar.SetSimVarValue("K:AP_PANEL_HEADING_HOLD", "Number", 1);
+        }
+    }
+    getIsTHRActive() {
+        return false;
+    }
+    getIsVSpeedActive() {
+        return this._isVSpeedActive;
+    }
+    toggleVSpeed() {
+        if (this.getIsVSpeedActive()) {
+            let altitude = Simplane.getAltitudeAboveGround();
+            if (altitude < 50) {
+                this.deactivateVSpeed();
+                this.deactivateSPD();
+            }
+            else {
+                this.activateVSpeed();
+            }
+        }
+        else {
+            this.activateVSpeed();
+        }
+    }
+    activateVSpeed() {
+        this._isVSpeedActive = true;
+        this.deactivateVNAV();
+        this.deactivateAltitudeHold();
+        this.deactivateFLCH();
+        this.activateSPD();
+        SimVar.SetSimVarValue("K:ALTITUDE_SLOT_INDEX_SET", "number", 1);
+        let displayedAltitude = Simplane.getAutoPilotDisplayedAltitudeLockValue();
+        Coherent.call("AP_ALT_VAR_SET_ENGLISH", 1, displayedAltitude, this._forceNextAltitudeUpdate);
+        setTimeout(() => {
+            let currentVSpeed = Simplane.getVerticalSpeed();
+            Coherent.call("AP_VS_VAR_SET_ENGLISH", 0, currentVSpeed);
+            if (!SimVar.GetSimVarValue("AUTOPILOT VERTICAL HOLD", "Boolean")) {
+                SimVar.SetSimVarValue("K:AP_PANEL_VS_HOLD", "Number", 1);
+            }
+        }, 200);
+        SimVar.SetSimVarValue("L:AP_VS_ACTIVE", "number", 1);
+    }
+    deactivateVSpeed() {
+        this._isVSpeedActive = false;
+        SimVar.SetSimVarValue("L:AP_VS_ACTIVE", "number", 0);
+    }
+    activateAltitudeSel() {
+        if (this.getIsVNAVActive()) {
+            let displayedAltitude = Simplane.getAutoPilotDisplayedAltitudeLockValue();
+            this.cruiseFlightLevel = Math.floor(displayedAltitude / 100);
+        }
+    }
+    toggleAltitudeHold() {
+        if (this.getIsAltitudeHoldActive()) {
+            let altitude = Simplane.getAltitudeAboveGround();
+            if (altitude < 50) {
+                this.deactivateAltitudeHold();
+                this.deactivateSPD();
+            }
+        }
+        else {
+            this.activateAltitudeHold();
+        }
+    }
+    getIsAltitudeHoldActive() {
+        return this._isAltitudeHoldActive;
+    }
+    activateAltitudeHold(useCurrentAutopilotTarget = false) {
+        this.deactivateVNAV();
+        this.deactivateFLCH();
+        this.deactivateVSpeed();
+        this.activateSPD();
+        this._isAltitudeHoldActive = true;
+        SimVar.SetSimVarValue("L:AP_ALT_HOLD_ACTIVE", "number", 1);
+        if (useCurrentAutopilotTarget) {
+            this._altitudeHoldValue = Simplane.getAutoPilotAltitudeLockValue("feet");
+        }
+        else {
+            this._altitudeHoldValue = Simplane.getAltitude();
+            this._altitudeHoldValue = Math.round(this._altitudeHoldValue / 100) * 100;
+        }
+        SimVar.SetSimVarValue("K:ALTITUDE_SLOT_INDEX_SET", "number", 1);
+        Coherent.call("AP_ALT_VAR_SET_ENGLISH", 1, this._altitudeHoldValue, this._forceNextAltitudeUpdate);
+        if (!SimVar.GetSimVarValue("AUTOPILOT ALTITUDE LOCK", "Boolean")) {
+            SimVar.SetSimVarValue("K:AP_PANEL_ALTITUDE_HOLD", "Number", 1);
+        }
+    }
+    deactivateAltitudeHold() {
+        this._isAltitudeHoldActive = false;
+        SimVar.SetSimVarValue("L:AP_ALT_HOLD_ACTIVE", "number", 0);
+        Coherent.call("AP_ALT_VAR_SET_ENGLISH", 1, Simplane.getAutoPilotDisplayedAltitudeLockValue(), this._forceNextAltitudeUpdate);
+        if (this._onAltitudeHoldDeactivate) {
+            let cb = this._onAltitudeHoldDeactivate;
+            this._onAltitudeHoldDeactivate = undefined;
+            cb();
+        }
+    }
+    getThrustTakeOffLimit() {
+        return 100;
+    }
+    getThrustClimbLimit() {
+        return 100;
+    }
+    getVRef(flapsHandleIndex = NaN, useCurrentWeight = true) {
+        return 200;
+    }
+    getTakeOffManagedSpeed() {
+        let altitude = Simplane.getAltitudeAboveGround();
+        if (altitude < 35) {
+            return this.v2Speed + 15;
+        }
+        return 250;
+    }
+    getIsRouteActivated() {
+        return this._isRouteActivated;
+    }
+    activateRoute() {
+        this._isRouteActivated = true;
+        SimVar.SetSimVarValue("L:FMC_EXEC_ACTIVE", "number", 1);
+    }
+    setBoeingDirectTo(directToWaypointIdent, directToWaypointIndex, callback = EmptyCallback.Boolean) {
+        let waypoints = this.flightPlanManager.getWaypoints();
+        let waypointIndex = waypoints.findIndex(w => { return w.ident === directToWaypointIdent; });
+        if (waypointIndex === -1) {
+            waypoints = this.flightPlanManager.getApproachWaypoints();
+            if (waypoints) {
+                let waypoint = waypoints.find(w => { return w.ident === directToWaypointIdent; });
+                if (waypoint) {
+                    return this.flightPlanManager.activateDirectTo(waypoint.icao, () => {
+                        return callback(true);
+                    });
+                }
+            }
+        }
+        if (waypointIndex > -1) {
+            this.setDepartureIndex(-1, () => {
+                let i = directToWaypointIndex;
+                let removeWaypointMethod = () => {
+                    if (i < waypointIndex) {
+                        console.log("Remove Waypoint " + this.flightPlanManager.getWaypoints()[directToWaypointIndex].ident);
+                        this.flightPlanManager.removeWaypoint(directToWaypointIndex, false, () => {
+                            i++;
+                            removeWaypointMethod();
+                        });
+                    }
+                    else {
+                        callback(true);
+                    }
+                };
+                removeWaypointMethod();
+            });
+        }
+        else {
+            callback(false);
+        }
+    }
+}
+//# sourceMappingURL=Boeing_FMC.js.map

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js
@@ -1,0 +1,2516 @@
+class FMCMainDisplay extends BaseAirliners {
+    constructor() {
+        super();
+        this.defaultInputErrorMessage = "INVALID ENTRY";
+        this.currentFlightPlanWaypointIndex = -1;
+        this._title = undefined;
+        this._pageCurrent = undefined;
+        this._pageCount = undefined;
+        this._labels = [];
+        this._lines = [];
+        this._inOut = undefined;
+        this.onLeftInput = [];
+        this.onRightInput = [];
+        this.lastPos = "";
+        this.costIndex = NaN;
+        this.lastUserInput = "";
+        this.isDisplayingErrorMessage = false;
+        this.maxCruiseFL = 390;
+        this.routeIndex = 0;
+        this.coRoute = "";
+        this.routeIsSelected = false;
+        this.routePageCurrent = 1;
+        this.routePageCount = 2;
+        this.tmpOrigin = "";
+        this.tmpDestination = "";
+        this.customV1Speed = false;
+        this.customVRSpeed = false;
+        this.customV2Speed = false;
+        this.transitionAltitude = 5000;
+        this.perfTOTemp = 20;
+        this.overSpeedLimitThreshold = false;
+        this._overridenFlapApproachSpeed = NaN;
+        this._overridenSlatApproachSpeed = NaN;
+        this.taxiFuelWeight = 0.2;
+        this._routeFinalFuelWeight = NaN;
+        this._routeFinalFuelTime = NaN;
+        this._routeReservedWeight = NaN;
+        this._routeReservedPercent = 0;
+        this.zeroFuelWeight = 0;
+        this.zeroFuelWeightMassCenter = 0;
+        this.takeOffTrim = 0;
+        this._takeOffFlap = -1;
+        this.blockFuel = 0;
+        this._fuelReserves = NaN;
+        this.takeOffWeight = NaN;
+        this.landingWeight = NaN;
+        this.averageWind = NaN;
+        this.perfCrzWindHeading = NaN;
+        this.perfCrzWindSpeed = NaN;
+        this.perfApprQNH = NaN;
+        this.perfApprTemp = NaN;
+        this.perfApprWindHeading = NaN;
+        this.perfApprWindSpeed = NaN;
+        this.perfApprTransAlt = NaN;
+        this.vApp = NaN;
+        this.perfApprMDA = NaN;
+        this.perfApprDH = NaN;
+        this._flightPhases = ["PREFLIGHT", "TAXI", "TAKEOFF", "CLIMB", "CRUISE", "DESCENT", "APPROACH", "GOAROUND"];
+        this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_TAKEOFF;
+        this._lockConnectIls = false;
+        this._apNavIndex = 1;
+        this._apLocalizerOn = false;
+        this._canSwitchToNav = false;
+        this.needApproachToSwitchToNav = true;
+        this._vhf1Frequency = 0;
+        this._vhf2Frequency = 0;
+        this._vor1Frequency = 0;
+        this._vor1Course = 0;
+        this._vor2Frequency = 0;
+        this._vor2Course = 0;
+        this._ilsFrequency = 0;
+        this._ilsCourse = 0;
+        this._adf1Frequency = 0;
+        this._adf2Frequency = 0;
+        this._rcl1Frequency = 0;
+        this._pre2Frequency = 0;
+        this._atc1Frequency = 0;
+        this._radioNavOn = false;
+        this._fuelVarsUpdatedGrossWeight = 0;
+        this._fuelVarsUpdatedTripCons = 0;
+        this._debug = 0;
+        this._checkUpdateFuel = 0;
+        this._checkFlightPlan = 0;
+        this._smoothedTargetHeading = NaN;
+        this._smootherTargetPitch = NaN;
+        FMCMainDisplay.DEBUG_INSTANCE = this;
+    }
+    static approachTypeStringToIndex(approachType) {
+        approachType = approachType.trim();
+        let index = FMCMainDisplay.approachTypes.indexOf(approachType);
+        if (isFinite(index) && index > 0) {
+            return index;
+        }
+        return 0;
+    }
+    getTitle() {
+        if (this._title === undefined) {
+            this._title = this._titleElement.textContent;
+        }
+        return this._title;
+    }
+    setTitle(content) {
+        let color = content.split("[color]")[1];
+        if (!color) {
+            color = "white";
+        }
+        this._title = content.split("[color]")[0];
+        this._titleElement.classList.remove("white", "blue", "yellow", "green", "red");
+        this._titleElement.classList.add(color);
+        this._titleElement.innerHTML = this._title;
+    }
+    getPageCurrent() {
+        if (this._pageCurrent === undefined) {
+            this._pageCurrent = parseInt(this._pageCurrentElement.textContent);
+        }
+        return this._pageCurrent;
+    }
+    setPageCurrent(value) {
+        if (typeof (value) === "number") {
+            this._pageCurrent = value;
+        }
+        else if (typeof (value) === "string") {
+            this._pageCurrent = parseInt(value);
+        }
+        this._pageCurrentElement.textContent = (this._pageCurrent > 0 ? this._pageCurrent : "") + "";
+    }
+    getPageCount() {
+        if (this._pageCount === undefined) {
+            this._pageCount = parseInt(this._pageCountElement.textContent);
+        }
+        return this._pageCount;
+    }
+    setPageCount(value) {
+        if (typeof (value) === "number") {
+            this._pageCount = value;
+        }
+        else if (typeof (value) === "string") {
+            this._pageCount = parseInt(value);
+        }
+        this._pageCountElement.textContent = (this._pageCount > 0 ? this._pageCount : "") + "";
+        if (this._pageCount === 0) {
+            this.getChildById("page-slash").textContent = "";
+        }
+        else {
+            this.getChildById("page-slash").textContent = "/";
+        }
+    }
+    getLabel(row, col = 0) {
+        if (!this._labels[row]) {
+            this._labels[row] = [];
+        }
+        return this._labels[row][col];
+    }
+    setLabel(label, row, col = -1) {
+        if (col >= this._labelElements[row].length) {
+            return;
+        }
+        if (!this._labels[row]) {
+            this._labels[row] = [];
+        }
+        if (!label) {
+            label = "";
+        }
+        if (col === -1) {
+            for (let i = 0; i < this._labelElements[row].length; i++) {
+                this._labels[row][i] = "";
+                this._labelElements[row][i].textContent = "";
+            }
+            col = 0;
+        }
+        if (label === "__FMCSEPARATOR") {
+            label = "------------------------";
+        }
+        if (label !== "") {
+            let color = label.split("[color]")[1];
+            if (!color) {
+                color = "white";
+            }
+            let e = this._labelElements[row][col];
+            e.classList.remove("white", "blue", "yellow", "green", "red");
+            e.classList.add(color);
+            label = label.split("[color]")[0];
+        }
+        this._labels[row][col] = label;
+        this._labelElements[row][col].textContent = label;
+    }
+    getLine(row, col = 0) {
+        if (!this._lines[row]) {
+            this._lines[row] = [];
+        }
+        return this._lines[row][col];
+    }
+    setLine(content, row, col = -1) {
+        if (col >= this._lineElements[row].length) {
+            return;
+        }
+        if (!content) {
+            content = "";
+        }
+        if (!this._lines[row]) {
+            this._lines[row] = [];
+        }
+        if (col === -1) {
+            for (let i = 0; i < this._lineElements[row].length; i++) {
+                this._lines[row][i] = "";
+                this._lineElements[row][i].textContent = "";
+            }
+            col = 0;
+        }
+        if (content === "__FMCSEPARATOR") {
+            content = "------------------------";
+        }
+        if (content !== "") {
+            if (content.indexOf("[s-text]") !== -1) {
+                content = content.replace("[s-text]", "");
+                this._lineElements[row][col].classList.add("s-text");
+            }
+            else {
+                this._lineElements[row][col].classList.remove("s-text");
+            }
+            let color = content.split("[color]")[1];
+            if (!color) {
+                color = "white";
+            }
+            let e = this._lineElements[row][col];
+            e.classList.remove("white", "blue", "yellow", "green", "red", "magenta");
+            e.classList.add(color);
+            content = content.split("[color]")[0];
+        }
+        content = content.replace("\<", "&lt");
+        this._lines[row][col] = content;
+        this._lineElements[row][col].innerHTML = this._lines[row][col];
+    }
+    get inOut() {
+        return this.getInOut();
+    }
+    getInOut() {
+        if (this._inOut === undefined) {
+            this._inOut = this._inOutElement.textContent;
+        }
+        return this._inOut;
+    }
+    set inOut(v) {
+        this.setInOut(v);
+    }
+    setInOut(content) {
+        this._inOut = content;
+        this._inOutElement.textContent = this._inOut;
+        if (content === FMCMainDisplay.clrValue) {
+            this._inOutElement.style.paddingLeft = "8%";
+        }
+        else {
+            this._inOutElement.style.paddingLeft = "";
+        }
+    }
+    setTemplate(template) {
+        if (template[0]) {
+            this.setTitle(template[0][0]);
+            this.setPageCurrent(template[0][1]);
+            this.setPageCount(template[0][2]);
+        }
+        for (let i = 0; i < 6; i++) {
+            let tIndex = 2 * i + 1;
+            if (template[tIndex]) {
+                if (template[tIndex][1] !== undefined) {
+                    this.setLabel(template[tIndex][0], i, 0);
+                    this.setLabel(template[tIndex][1], i, 1);
+                    this.setLabel(template[tIndex][2], i, 2);
+                    this.setLabel(template[tIndex][3], i, 3);
+                }
+                else {
+                    this.setLabel(template[tIndex][0], i, -1);
+                }
+            }
+            tIndex = 2 * i + 2;
+            if (template[tIndex]) {
+                if (template[tIndex][1] !== undefined) {
+                    this.setLine(template[tIndex][0], i, 0);
+                    this.setLine(template[tIndex][1], i, 1);
+                    this.setLine(template[tIndex][2], i, 2);
+                    this.setLine(template[tIndex][3], i, 3);
+                }
+                else {
+                    this.setLine(template[tIndex][0], i, -1);
+                }
+            }
+        }
+        if (template[13]) {
+            this.setInOut(template[13][0]);
+        }
+        SimVar.SetSimVarValue("L:AIRLINER_MCDU_CURRENT_FPLN_WAYPOINT", "number", this.currentFlightPlanWaypointIndex);
+    }
+    getNavDataDateRange() {
+        return SimVar.GetGameVarValue("FLIGHT NAVDATA DATE RANGE", "string");
+    }
+    get cruiseFlightLevel() {
+        return this._cruiseFlightLevel;
+    }
+    set cruiseFlightLevel(fl) {
+        this._cruiseFlightLevel = Math.round(fl / 5) * 5;
+        SimVar.SetSimVarValue("L:AIRLINER_CRUISE_ALTITUDE", "number", this._cruiseFlightLevel * 100);
+    }
+    getCostIndexFactor() {
+        if (isFinite(this.costIndex)) {
+            return this.costIndex / 999;
+        }
+        return 0.1;
+    }
+    clearUserInput() {
+        if (!this.isDisplayingErrorMessage) {
+            this.lastUserInput = this.inOut;
+        }
+        this.inOut = "";
+    }
+    showErrorMessage(message) {
+        this.isDisplayingErrorMessage = true;
+        this.inOut = message;
+    }
+    async tryUpdateRefAirport(airportIdent) {
+        let airport = await this.dataManager.GetAirportByIdent(airportIdent);
+        if (!airport) {
+            this.showErrorMessage("NOT IN DATABASE");
+            return false;
+        }
+        this.refAirport = airport;
+        return true;
+    }
+    tryUpdateGate(gate) {
+        if (gate.length > 6) {
+            this.showErrorMessage(this.defaultInputErrorMessage);
+            return false;
+        }
+        this.refGate = gate;
+        return true;
+    }
+    tryUpdateHeading(heading) {
+        let nHeading = parseInt(heading);
+        if (isNaN(nHeading)) {
+            this.showErrorMessage(this.defaultInputErrorMessage);
+            return false;
+        }
+        nHeading = Math.round(nHeading) % 360;
+        this.refHeading = nHeading;
+        return true;
+    }
+    async tryUpdateIrsCoordinatesDisplay(newIrsCoordinatesDisplay) {
+        if (!this.dataManager.IsValidLatLon(newIrsCoordinatesDisplay)) {
+            this.showErrorMessage(this.defaultInputErrorMessage);
+            return false;
+        }
+        this.initCoordinates = newIrsCoordinatesDisplay;
+        this.lastPos = this.initCoordinates;
+        return true;
+    }
+    setCruiseFlightLevelAndTemperature(input) {
+        if (input === FMCMainDisplay.clrValue) {
+            this.cruiseFlightLevel = undefined;
+            this.cruiseTemperature = undefined;
+            return true;
+        }
+        let flString = input.split("/")[0].replace("FL", "");
+        let tempString = input.split("/")[1];
+        let onlyTemp = flString.length === 0;
+        if (tempString) {
+            let temp = parseFloat(tempString);
+            if (isFinite(temp)) {
+                if (temp > -270 && temp < 100) {
+                    this.cruiseTemperature = temp;
+                }
+                else {
+                    if (onlyTemp) {
+                        this.showErrorMessage("ENTRY OUT OF RANGE");
+                        return false;
+                    }
+                }
+            }
+            else {
+                if (onlyTemp) {
+                    this.showErrorMessage(this.defaultInputErrorMessage);
+                    return false;
+                }
+            }
+        }
+        if (flString) {
+            let fl = parseFloat(flString);
+            if (isFinite(fl)) {
+                if (fl > 0 && fl <= this.maxCruiseFL) {
+                    this.cruiseFlightLevel = fl;
+                    return true;
+                }
+                else if (fl >= 1000 && fl <= this.maxCruiseFL * 100) {
+                    this.cruiseFlightLevel = Math.floor(fl / 100);
+                    return true;
+                }
+                this.showErrorMessage("ENTRY OUT OF RANGE");
+                return false;
+            }
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    trySetGroundTemperature(groundTemperature) {
+        let value = parseInt(groundTemperature);
+        if (isFinite(value)) {
+            this.groundTemperature = value;
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    tryUpdateCostIndex(costIndex, maxValue = 1000) {
+        let value = parseInt(costIndex);
+        if (isFinite(value)) {
+            if (value >= 0) {
+                if (value < maxValue) {
+                    this.costIndex = value;
+                    return true;
+                }
+            }
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    ensureCurrentFlightPlanIsTemporary(callback = EmptyCallback.Boolean) {
+        if (this.flightPlanManager.getCurrentFlightPlanIndex() === 0) {
+            this.flightPlanManager.copyCurrentFlightPlanInto(1, () => {
+                this.flightPlanManager.setCurrentFlightPlanIndex(1, (result) => {
+                    SimVar.SetSimVarValue("L:FMC_FLIGHT_PLAN_IS_TEMPORARY", "number", 1);
+                    SimVar.SetSimVarValue("L:MAP_SHOW_TEMPORARY_FLIGHT_PLAN", "number", 1);
+                    callback(result);
+                });
+            });
+        }
+        else {
+            callback(true);
+        }
+    }
+    tryUpdateFromTo(fromTo, callback = EmptyCallback.Boolean) {
+        if (fromTo === FMCMainDisplay.clrValue) {
+            this.showErrorMessage("NOT ALLOWED");
+            return callback(false);
+        }
+        let from = fromTo.split("/")[0];
+        let to = fromTo.split("/")[1];
+        this.dataManager.GetAirportByIdent(from).then((airportFrom) => {
+            if (airportFrom) {
+                this.dataManager.GetAirportByIdent(to).then((airportTo) => {
+                    if (airportTo) {
+                        this.eraseTemporaryFlightPlan(() => {
+                            this.flightPlanManager.clearFlightPlan(() => {
+                                this.flightPlanManager.setOrigin(airportFrom.icao, () => {
+                                    this.tmpOrigin = airportFrom.ident;
+                                    this.flightPlanManager.setDestination(airportTo.icao, () => {
+                                        this.recalculateTHRRedAccTransAlt();
+                                        this.tmpOrigin = airportTo.ident;
+                                        this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_TAKEOFF;
+                                        callback(true);
+                                    });
+                                });
+                            });
+                        });
+                    }
+                    else {
+                        this.showErrorMessage("NOT IN DATABASE");
+                        callback(false);
+                    }
+                });
+            }
+            else {
+                this.showErrorMessage("NOT IN DATABASE");
+                callback(false);
+            }
+        });
+    }
+    async tryUpdateAltDestination(altDestIdent) {
+        if (altDestIdent === "NONE") {
+            this.altDestination = undefined;
+            return true;
+        }
+        let airportAltDest = await this.dataManager.GetAirportByIdent(altDestIdent);
+        if (airportAltDest) {
+            this.altDestination = airportAltDest;
+            return true;
+        }
+        this.showErrorMessage("NOT IN DATABASE");
+        return false;
+    }
+    updateRouteOrigin(newRouteOrigin, callback = EmptyCallback.Boolean) {
+        this.dataManager.GetAirportByIdent(newRouteOrigin).then(airport => {
+            if (!airport) {
+                this.showErrorMessage("NOT IN DATABASE");
+                return callback(false);
+            }
+            this.flightPlanManager.clearFlightPlan(() => {
+                this.flightPlanManager.setOrigin(airport.icao, () => {
+                    this.tmpOrigin = airport.ident;
+                    this.recalculateTHRRedAccTransAlt();
+                    callback(true);
+                });
+            });
+        });
+    }
+    updateRouteDestination(routeDestination, callback = EmptyCallback.Boolean) {
+        this.dataManager.GetAirportByIdent(routeDestination).then(airport => {
+            if (!airport) {
+                this.showErrorMessage("NOT IN DATABASE");
+                return callback(false);
+            }
+            this.flightPlanManager.setDestination(airport.icao, () => {
+                this.tmpDestination = airport.ident;
+                this.recalculateTHRRedAccTransAlt();
+                callback(true);
+            });
+        });
+    }
+    setOriginRunway(runwayName, callback = EmptyCallback.Boolean) {
+        let origin = this.flightPlanManager.getOrigin();
+        if (origin && origin.infos instanceof AirportInfo) {
+            let runwayIndex = origin.infos.oneWayRunways.findIndex(r => { return Avionics.Utils.formatRunway(r.designation) === Avionics.Utils.formatRunway(runwayName); });
+            if (runwayIndex >= 0) {
+                this.ensureCurrentFlightPlanIsTemporary(() => {
+                    this.flightPlanManager.setOriginRunwayIndex(runwayIndex, () => {
+                        return callback(true);
+                    });
+                });
+            }
+            else {
+                this.showErrorMessage("NOT IN DATABASE");
+                return callback(false);
+            }
+        }
+        else {
+            this.showErrorMessage("NO ORIGIN AIRPORT");
+            return callback(false);
+        }
+    }
+    setOriginRunwayIndex(runwayIndex, callback = EmptyCallback.Boolean) {
+        this.ensureCurrentFlightPlanIsTemporary(() => {
+            this.flightPlanManager.setDepartureProcIndex(-1, () => {
+                this.flightPlanManager.setOriginRunwayIndex(runwayIndex, () => {
+                    return callback(true);
+                });
+            });
+        });
+    }
+    setRunwayIndex(runwayIndex, callback = EmptyCallback.Boolean) {
+        this.ensureCurrentFlightPlanIsTemporary(() => {
+            let routeOriginInfo = this.flightPlanManager.getOrigin().infos;
+            if (!this.flightPlanManager.getOrigin()) {
+                this.showErrorMessage("NO ORIGIN SET");
+                return callback(false);
+            }
+            else if (runwayIndex === -1) {
+                this.flightPlanManager.setDepartureRunwayIndex(-1, () => {
+                    this.flightPlanManager.setOriginRunwayIndex(-1, () => {
+                        return callback(true);
+                    });
+                });
+            }
+            else if (routeOriginInfo instanceof AirportInfo) {
+                if (routeOriginInfo.oneWayRunways[runwayIndex]) {
+                    this.flightPlanManager.setDepartureRunwayIndex(runwayIndex, () => {
+                        return callback(true);
+                    });
+                }
+            }
+            else {
+                this.showErrorMessage("NOT IN DATABASE");
+                callback(false);
+            }
+        });
+    }
+    setDepartureIndex(departureIndex, callback = EmptyCallback.Boolean) {
+        this.ensureCurrentFlightPlanIsTemporary(() => {
+            let currentRunway = this.flightPlanManager.getDepartureRunway();
+            this.flightPlanManager.setDepartureProcIndex(departureIndex, () => {
+                if (currentRunway) {
+                    let departure = this.flightPlanManager.getDeparture();
+                    let departureRunwayIndex = departure.runwayTransitions.findIndex(t => {
+                        return t.name.indexOf(currentRunway.designation) != -1;
+                    });
+                    if (departureRunwayIndex >= -1) {
+                        return this.flightPlanManager.setDepartureRunwayIndex(departureRunwayIndex, () => {
+                            return callback(true);
+                        });
+                    }
+                }
+                return callback(true);
+            });
+        });
+    }
+    removeDeparture() {
+        this.flightPlanManager.removeDeparture();
+        return true;
+    }
+    setApproachTransitionIndex(transitionIndex, callback = EmptyCallback.Boolean) {
+        let arrivalIndex = this.flightPlanManager.getArrivalProcIndex();
+        this.ensureCurrentFlightPlanIsTemporary(() => {
+            this.flightPlanManager.setApproachTransitionIndex(transitionIndex, () => {
+                this.flightPlanManager.setArrivalProcIndex(arrivalIndex, () => {
+                    callback(true);
+                });
+            });
+        });
+    }
+    setArrivalProcIndex(arrivalIndex, callback = EmptyCallback.Boolean) {
+        this.ensureCurrentFlightPlanIsTemporary(() => {
+            this.flightPlanManager.setArrivalProcIndex(arrivalIndex, () => {
+                callback(true);
+            });
+        });
+    }
+    setArrivalIndex(arrivalIndex, transitionIndex, callback = EmptyCallback.Boolean) {
+        this.ensureCurrentFlightPlanIsTemporary(() => {
+            this.flightPlanManager.setArrivalEnRouteTransitionIndex(transitionIndex, () => {
+                this.flightPlanManager.setArrivalProcIndex(arrivalIndex, () => {
+                    callback(true);
+                });
+            });
+        });
+    }
+    removeArrival() {
+        this.flightPlanManager.removeDeparture();
+        return true;
+    }
+    setApproachIndex(approachIndex, callback = EmptyCallback.Boolean) {
+        this.ensureCurrentFlightPlanIsTemporary(() => {
+            this.flightPlanManager.setApproachIndex(approachIndex, () => {
+                let frequency = this.flightPlanManager.getApproachNavFrequency();
+                if (isFinite(frequency)) {
+                    let freq = Math.round(frequency * 100) / 100;
+                    if (this.connectIlsFrequency(freq)) {
+                        SimVar.SetSimVarValue("L:FLIGHTPLAN_APPROACH_ILS", "number", freq);
+                        let approach = this.flightPlanManager.getApproach();
+                        if (approach && approach.name && approach.name.indexOf("ILS") !== -1) {
+                            let runway = this.flightPlanManager.getApproachRunway();
+                            if (runway) {
+                                SimVar.SetSimVarValue("L:FLIGHTPLAN_APPROACH_COURSE", "number", runway.direction);
+                            }
+                        }
+                    }
+                }
+                callback(true);
+            });
+        });
+    }
+    updateFlightNo(flightNo, callback = EmptyCallback.Boolean) {
+        if (flightNo.length > 7) {
+            this.showErrorMessage(this.defaultInputErrorMessage);
+            return callback(false);
+        }
+        SimVar.SetSimVarValue("ATC FLIGHT NUMBER", "string", flightNo, "FMC").then(() => {
+            return callback(true);
+        });
+    }
+    updateCoRoute(coRoute, callback = EmptyCallback.Boolean) {
+        if (coRoute.length > 2) {
+            if (coRoute.length < 10) {
+                if (coRoute === "NONE") {
+                    this.coRoute = undefined;
+                }
+                else {
+                    this.coRoute = coRoute;
+                }
+                return callback(true);
+            }
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return callback(false);
+    }
+    getTotalTripTime() {
+        if (this.flightPlanManager.getOrigin()) {
+            return this.flightPlanManager.getOrigin().infos.totalTimeInFP;
+        }
+        return NaN;
+    }
+    getTotalTripFuelCons() {
+        if (this.flightPlanManager.getDestination()) {
+            return this.flightPlanManager.getOrigin().infos.totalFuelConsInFP;
+        }
+        return NaN;
+    }
+    getOrSelectWaypointByIdent(ident, callback) {
+        this.dataManager.GetWaypointsByIdent(ident).then((waypoints) => {
+            if (!waypoints || waypoints.length === 0) {
+                return callback(undefined);
+            }
+            return callback(waypoints[0]);
+        });
+    }
+    async tryAddNextAirway(newAirway) {
+        this.showErrorMessage("NOT IMPLEMENTED");
+        return false;
+    }
+    async tryAddNextWaypoint(newWaypointTo) {
+        let waypoints = await this.dataManager.GetWaypointsByIdent(newWaypointTo);
+        if (waypoints.length === 0) {
+            this.showErrorMessage("NOT IN DATABASE");
+            return false;
+        }
+        if (waypoints.length === 1) {
+            this.flightPlanManager.addWaypoint(waypoints[0].icao);
+            this.routeIsSelected = false;
+            return true;
+        }
+        return false;
+    }
+    activateDirectToWaypointIdent(waypointIdent, callback = EmptyCallback.Void) {
+        this.getOrSelectWaypointByIdent(waypointIdent, (w) => {
+            if (w) {
+                return this.activateDirectToWaypoint(w, callback);
+            }
+            return callback();
+        });
+    }
+    activateDirectToWaypoint(waypoint, callback = EmptyCallback.Void) {
+        this.flightPlanManager.activateDirectTo(waypoint.infos.icao, callback);
+    }
+    insertWaypointNextTo(newWaypointTo, referenceWaypoint, callback = EmptyCallback.Boolean) {
+        let referenceWaypointIndex = this.flightPlanManager.indexOfWaypoint(referenceWaypoint);
+        if (referenceWaypointIndex >= 0) {
+            return this.insertWaypoint(newWaypointTo, referenceWaypointIndex + 1, callback);
+        }
+        this.showErrorMessage("NOT IN DATABASE");
+        callback(false);
+    }
+    insertWaypoint(newWaypointTo, index, callback = EmptyCallback.Boolean) {
+        this.ensureCurrentFlightPlanIsTemporary(async () => {
+            this.getOrSelectWaypointByIdent(newWaypointTo, (waypoint) => {
+                if (!waypoint) {
+                    this.showErrorMessage("NOT IN DATABASE");
+                    return callback(false);
+                }
+                this.flightPlanManager.addWaypoint(waypoint.icao, index, () => {
+                    return callback(true);
+                });
+            });
+        });
+    }
+    insertWaypointsAlongAirway(lastWaypointIdent, index, airwayName, callback = EmptyCallback.Boolean) {
+        let referenceWaypoint = this.flightPlanManager.getWaypoint(index - 1);
+        if (referenceWaypoint) {
+            let infos = referenceWaypoint.infos;
+            if (infos instanceof WayPointInfo) {
+                let airway = infos.airways.find(a => { return a.name === airwayName; });
+                if (airway) {
+                    let firstIndex = airway.icaos.indexOf(referenceWaypoint.icao);
+                    let lastWaypointIcao = airway.icaos.find(icao => { return icao.indexOf(lastWaypointIdent) !== -1; });
+                    let lastIndex = airway.icaos.indexOf(lastWaypointIcao);
+                    if (firstIndex >= 0) {
+                        if (lastIndex >= 0) {
+                            let inc = 1;
+                            if (lastIndex < firstIndex) {
+                                inc = -1;
+                            }
+                            let count = Math.abs(lastIndex - firstIndex);
+                            let asyncInsertWaypointByIcao = async (icao, index) => {
+                                return new Promise(resolve => {
+                                    this.flightPlanManager.addWaypoint(icao, index, () => {
+                                        resolve();
+                                    });
+                                });
+                            };
+                            let outOfSync = async () => {
+                                await asyncInsertWaypointByIcao(airway.icaos[firstIndex + count * inc], index);
+                                callback(true);
+                            };
+                            outOfSync();
+                            return;
+                        }
+                        this.showErrorMessage("2ND INDEX NOT FOUND");
+                        return callback(false);
+                    }
+                    this.showErrorMessage("1ST INDEX NOT FOUND");
+                    return callback(false);
+                }
+                this.showErrorMessage("NO REF WAYPOINT");
+                return callback(false);
+            }
+            this.showErrorMessage("NO WAYPOINT INFOS");
+            return callback(false);
+        }
+        this.showErrorMessage("NO REF WAYPOINT");
+        return callback(false);
+    }
+    async tryInsertAirwayByWaypointIdent(newWaypointIdent, from) {
+        this.showErrorMessage("NOT IMPLEMENTED");
+        return false;
+    }
+    async tryInsertAirway(newAirway, from) {
+        this.showErrorMessage("NOT IMPLEMENTED");
+        return false;
+    }
+    removeWaypoint(index, callback = EmptyCallback.Void) {
+        this.ensureCurrentFlightPlanIsTemporary(() => {
+            this.flightPlanManager.removeWaypoint(index, true, callback);
+        });
+    }
+    async tryUpdateWaypointVia(via, waypointIndex) {
+        this.showErrorMessage("NOT IMPLEMENTED");
+        return false;
+    }
+    clearDepartureDiscontinuity(callback = EmptyCallback.Void) {
+        this.flightPlanManager.clearDepartureDiscontinuity(callback);
+    }
+    clearArrivalDiscontinuity(callback = EmptyCallback.Void) {
+        this.flightPlanManager.clearArrivalDiscontinuity(callback);
+    }
+    eraseTemporaryFlightPlan(callback = EmptyCallback.Void) {
+        this.flightPlanManager.setCurrentFlightPlanIndex(0, () => {
+            SimVar.SetSimVarValue("L:FMC_FLIGHT_PLAN_IS_TEMPORARY", "number", 0);
+            SimVar.SetSimVarValue("L:MAP_SHOW_TEMPORARY_FLIGHT_PLAN", "number", 0);
+            callback();
+        });
+    }
+    insertTemporaryFlightPlan(callback = EmptyCallback.Void) {
+        if (this.flightPlanManager.getCurrentFlightPlanIndex() === 1) {
+            this.flightPlanManager.copyCurrentFlightPlanInto(0, () => {
+                this.flightPlanManager.setCurrentFlightPlanIndex(0, () => {
+                    SimVar.SetSimVarValue("L:FMC_FLIGHT_PLAN_IS_TEMPORARY", "number", 0);
+                    SimVar.SetSimVarValue("L:MAP_SHOW_TEMPORARY_FLIGHT_PLAN", "number", 0);
+                    if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_APPROACH) {
+                        this.flightPlanManager.activateApproach();
+                    }
+                    callback();
+                });
+            });
+        }
+    }
+    _computeV1Speed() {
+        this.v1Speed = 120;
+        SimVar.SetSimVarValue("L:AIRLINER_V1_SPEED", "Knots", this.v1Speed);
+    }
+    _computeVRSpeed() {
+        this.vRSpeed = 130;
+        SimVar.SetSimVarValue("L:AIRLINER_VR_SPEED", "Knots", this.vRSpeed);
+    }
+    _computeV2Speed() {
+        this.v2Speed = 140;
+        SimVar.SetSimVarValue("L:AIRLINER_V2_SPEED", "Knots", this.v2Speed);
+    }
+    trySetV1Speed(s) {
+        if (s != undefined) {
+            if (!/^\d+$/.test(s)) {
+                this.showErrorMessage("FORMAT ERROR");
+                return false;
+            }
+            let v = parseInt(s);
+            if (isFinite(v)) {
+                if (v >= 0 && v < 1000) {
+                    this.v1Speed = v;
+                    this.customV1Speed = true;
+                    SimVar.SetSimVarValue("L:AIRLINER_V1_SPEED", "Knots", this.v1Speed);
+                    return true;
+                }
+                this.showErrorMessage("ENTRY OUT OF RANGE");
+                return false;
+            }
+            this.showErrorMessage(this.defaultInputErrorMessage);
+            return false;
+        }
+        else {
+            this.v1Speed = undefined;
+            this.customV1Speed = true;
+            SimVar.SetSimVarValue("L:AIRLINER_V1_SPEED", "Knots", 0);
+            return true;
+        }
+    }
+    trySetVRSpeed(s) {
+        if (s != undefined) {
+            if (!/^\d+$/.test(s)) {
+                this.showErrorMessage("FORMAT ERROR");
+                return false;
+            }
+            let v = parseInt(s);
+            if (isFinite(v)) {
+                if (v >= 0 && v < 1000) {
+                    this.vRSpeed = v;
+                    this.customVRSpeed = true;
+                    SimVar.SetSimVarValue("L:AIRLINER_VR_SPEED", "Knots", this.vRSpeed);
+                    return true;
+                }
+                this.showErrorMessage("ENTRY OUT OF RANGE");
+                return false;
+            }
+            this.showErrorMessage(this.defaultInputErrorMessage);
+            return false;
+        }
+        else {
+            this.vRSpeed = undefined;
+            this.customVRSpeed = true;
+            SimVar.SetSimVarValue("L:AIRLINER_VR_SPEED", "Knots", 0);
+            return true;
+        }
+    }
+    trySetV2Speed(s) {
+        if (s != undefined) {
+            if (!/^\d+$/.test(s)) {
+                this.showErrorMessage("FORMAT ERROR");
+                return false;
+            }
+            let v = parseInt(s);
+            if (isFinite(v)) {
+                if (v > 0 && v < 1000) {
+                    this.v2Speed = v;
+                    this.customV2Speed = true;
+                    SimVar.SetSimVarValue("L:AIRLINER_V2_SPEED", "Knots", this.v2Speed);
+                    return true;
+                }
+                this.showErrorMessage("ENTRY OUT OF RANGE");
+                return false;
+            }
+            this.showErrorMessage(this.defaultInputErrorMessage);
+            return false;
+        }
+        else {
+            this.v2Speed = undefined;
+            this.customV2Speed = true;
+            SimVar.SetSimVarValue("L:AIRLINER_V2_SPEED", "Knots", 0);
+            return true;
+        }
+    }
+    trySetTransAltitude(s) {
+        if (!/^\d+$/.test(s)) {
+            this.showErrorMessage("FORMAT ERROR");
+            return false;
+        }
+        let v = parseInt(s);
+        if (isFinite(v) && v > 0) {
+            this.transitionAltitude = v;
+            SimVar.SetSimVarValue("L:AIRLINER_TRANS_ALT", "Number", this.v2Speed);
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    trySetThrustReductionAccelerationAltitude(s) {
+        let thrRed = NaN;
+        let accAlt = NaN;
+        if (s) {
+            let sSplit = s.split("/");
+            thrRed = parseInt(sSplit[0]);
+            accAlt = parseInt(sSplit[1]);
+        }
+        if (isFinite(thrRed) || isFinite(accAlt)) {
+            if (isFinite(thrRed)) {
+                this.thrustReductionAltitude = thrRed;
+                SimVar.SetSimVarValue("L:AIRLINER_THR_RED_ALT", "Number", this.thrustReductionAltitude);
+            }
+            if (isFinite(accAlt)) {
+                this.accelerationAltitude = accAlt;
+                SimVar.SetSimVarValue("L:AIRLINER_ACC_ALT", "Number", this.accelerationAltitude);
+            }
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    trySetFlapsTHS(s) {
+        if (s) {
+            let flaps = s.split("/")[0];
+            let validEntry = false;
+            if (!/^\d+$/.test(flaps)) {
+                this.showErrorMessage("FORMAT ERROR");
+                return false;
+            }
+            let vFlaps = parseInt(flaps);
+            if (isFinite(vFlaps)) {
+                this.flaps = vFlaps;
+                validEntry = true;
+            }
+            let vThs = s.split("/")[1];
+            if (vThs) {
+                if (vThs.substr(0, 2) === "UP" || vThs.substr(0, 2) === "DN") {
+                    if (isFinite(parseFloat(vThs.substr(2)))) {
+                        this.ths = vThs;
+                        validEntry = true;
+                    }
+                }
+            }
+            if (validEntry) {
+                return true;
+            }
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    getFlapSpeed() {
+        let phase = Simplane.getCurrentFlightPhase();
+        let flapsHandleIndex = Simplane.getFlapsHandleIndex();
+        let flapSpeed = 100;
+        if (flapsHandleIndex == 1) {
+            let slatSpeed = 0;
+            if (phase == FlightPhase.FLIGHT_PHASE_TAKEOFF || phase == FlightPhase.FLIGHT_PHASE_CLIMB || phase == FlightPhase.FLIGHT_PHASE_GOAROUND) {
+                slatSpeed = Simplane.getStallSpeedPredicted(flapsHandleIndex - 1) * 1.25;
+            }
+            else if (phase == FlightPhase.FLIGHT_PHASE_DESCENT || phase == FlightPhase.FLIGHT_PHASE_APPROACH) {
+                slatSpeed = Simplane.getStallSpeedPredicted(flapsHandleIndex + 1) * 1.23;
+            }
+            return slatSpeed;
+        }
+        if (flapsHandleIndex == 2 || flapsHandleIndex == 3) {
+            if (phase == FlightPhase.FLIGHT_PHASE_TAKEOFF || phase == FlightPhase.FLIGHT_PHASE_CLIMB || phase == FlightPhase.FLIGHT_PHASE_GOAROUND) {
+                flapSpeed = Simplane.getStallSpeedPredicted(flapsHandleIndex - 1) * 1.26;
+            }
+            else if (phase == FlightPhase.FLIGHT_PHASE_DESCENT || phase == FlightPhase.FLIGHT_PHASE_APPROACH) {
+                if (flapsHandleIndex == 2)
+                    flapSpeed = Simplane.getStallSpeedPredicted(flapsHandleIndex + 1) * 1.47;
+                else
+                    flapSpeed = Simplane.getStallSpeedPredicted(flapsHandleIndex + 1) * 1.36;
+            }
+        }
+        return flapSpeed;
+    }
+    getFlapTakeOffSpeed() {
+        let dWeight = (this.getWeight() - 42) / (75 - 42);
+        return 134 + 40 * dWeight;
+    }
+    getSlatTakeOffSpeed() {
+        let dWeight = (this.getWeight() - 42) / (75 - 42);
+        return 183 + 40 * dWeight;
+    }
+    getCleanTakeOffSpeed() {
+        let dWeight = (this.getWeight() - 42) / (75 - 42);
+        return 204 + 40 * dWeight;
+    }
+    updateCleanTakeOffSpeed() {
+        let toGreenDotSpeed = this.getCleanTakeOffSpeed();
+        if (isFinite(toGreenDotSpeed)) {
+            SimVar.SetSimVarValue("L:AIRLINER_TO_GREEN_DOT_SPD", "Number", toGreenDotSpeed);
+        }
+    }
+    setPerfTOFlexTemp(s) {
+        let value = parseFloat(s);
+        if (isFinite(value) && value > -270 && value < 150) {
+            this.perfTOTemp = value;
+            SimVar.SetSimVarValue("L:AIRLINER_TO_FLEX_TEMP", "Number", this.perfTOTemp);
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    getClbManagedSpeed() {
+        let dCI = this.getCostIndexFactor();
+        let flapsHandleIndex = Simplane.getFlapsHandleIndex();
+        if (flapsHandleIndex != 0) {
+            return this.getFlapSpeed();
+        }
+        let speed = 220 * (1 - dCI) + 280 * dCI;
+        if (this.overSpeedLimitThreshold) {
+            if (Simplane.getAltitude() < 9800) {
+                speed = Math.min(speed, 250);
+                this.overSpeedLimitThreshold = false;
+            }
+        }
+        else if (!this.overSpeedLimitThreshold) {
+            if (Simplane.getAltitude() < 10000) {
+                speed = Math.min(speed, 250);
+            }
+            else {
+                this.overSpeedLimitThreshold = true;
+            }
+        }
+        return speed;
+    }
+    getCrzManagedSpeed() {
+        let dCI = this.getCostIndexFactor();
+        dCI = dCI * dCI;
+        let flapsHandleIndex = SimVar.GetSimVarValue("FLAPS HANDLE INDEX", "Number");
+        if (flapsHandleIndex != 0) {
+            return this.getFlapSpeed();
+        }
+        let speed = 285 * (1 - dCI) + 310 * dCI;
+        if (this.overSpeedLimitThreshold) {
+            if (Simplane.getAltitude() < 9800) {
+                speed = Math.min(speed, 250);
+                this.overSpeedLimitThreshold = false;
+            }
+        }
+        else if (!this.overSpeedLimitThreshold) {
+            if (Simplane.getAltitude() < 10000) {
+                speed = Math.min(speed, 250);
+            }
+            else {
+                this.overSpeedLimitThreshold = true;
+            }
+        }
+        return speed;
+    }
+    getDesManagedSpeed() {
+        let dCI = this.getCostIndexFactor();
+        let flapsHandleIndex = Simplane.getFlapsHandleIndex();
+        if (flapsHandleIndex != 0) {
+            return this.getFlapSpeed();
+        }
+        let speed = 240 * (1 - dCI) + 260 * dCI;
+        if (this.overSpeedLimitThreshold) {
+            if (Simplane.getAltitude() < 9800) {
+                speed = Math.min(speed, 250);
+                this.overSpeedLimitThreshold = false;
+            }
+        }
+        else if (!this.overSpeedLimitThreshold) {
+            if (Simplane.getAltitude() < 10000) {
+                speed = Math.min(speed, 250);
+            }
+            else {
+                this.overSpeedLimitThreshold = true;
+            }
+        }
+        return speed;
+    }
+    getFlapApproachSpeed(useCurrentWeight = true) {
+        if (isFinite(this._overridenFlapApproachSpeed)) {
+            return this._overridenFlapApproachSpeed;
+        }
+        let dWeight = ((useCurrentWeight ? this.getWeight() : this.zeroFuelWeight) - 42) / (75 - 42);
+        dWeight = Math.min(Math.max(dWeight, 0), 1);
+        let base = Math.max(150, this.getVLS() + 5);
+        return base + 40 * dWeight;
+    }
+    setFlapApproachSpeed(s) {
+        if (s === FMCMainDisplay.clrValue) {
+            this._overridenFlapApproachSpeed = NaN;
+            return true;
+        }
+        let v = parseFloat(s);
+        if (isFinite(v)) {
+            if (v > 0 && v < 300) {
+                this._overridenFlapApproachSpeed = v;
+                return true;
+            }
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    getSlatApproachSpeed(useCurrentWeight = true) {
+        if (isFinite(this._overridenSlatApproachSpeed)) {
+            return this._overridenSlatApproachSpeed;
+        }
+        let dWeight = ((useCurrentWeight ? this.getWeight() : this.zeroFuelWeight) - 42) / (75 - 42);
+        dWeight = Math.min(Math.max(dWeight, 0), 1);
+        let base = Math.max(157, this.getVLS() + 5);
+        return base + 40 * dWeight;
+    }
+    setSlatApproachSpeed(s) {
+        if (s === FMCMainDisplay.clrValue) {
+            this._overridenSlatApproachSpeed = NaN;
+            return true;
+        }
+        let v = parseFloat(s);
+        if (isFinite(v)) {
+            if (v > 0 && v < 300) {
+                this._overridenSlatApproachSpeed = v;
+                return true;
+            }
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    getCleanApproachSpeed() {
+        let dWeight = (this.getWeight() - 42) / (75 - 42);
+        dWeight = Math.min(Math.max(dWeight, 0), 1);
+        let base = Math.max(172, this.getVLS() + 5);
+        return base + 40 * dWeight;
+    }
+    getManagedApproachSpeed(flapsHandleIndex = NaN) {
+        if (isNaN(flapsHandleIndex)) {
+            flapsHandleIndex = Simplane.getFlapsHandleIndex();
+        }
+        if (flapsHandleIndex === 0) {
+            return this.getCleanApproachSpeed();
+        }
+        else if (flapsHandleIndex === 1) {
+            return this.getSlatApproachSpeed();
+        }
+        else if (flapsHandleIndex === 2) {
+            return this.getFlapApproachSpeed();
+        }
+        else {
+            return this.getVApp();
+        }
+    }
+    updateCleanApproachSpeed() {
+        let apprGreenDotSpeed = this.getCleanApproachSpeed();
+        if (isFinite(apprGreenDotSpeed)) {
+            SimVar.SetSimVarValue("L:AIRLINER_APPR_GREEN_DOT_SPD", "Number", apprGreenDotSpeed);
+        }
+    }
+    async trySetTaxiFuelWeight(s) {
+        if (!/[0-9]+(\.[0-9][0-9]?)?/.test(s)) {
+            this.showErrorMessage("FORMAT ERROR");
+            return false;
+        }
+        let value = parseFloat(s);
+        if (isFinite(value) && value >= 0) {
+            this.taxiFuelWeight = value;
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    getRouteFinalFuelWeight() {
+        if (isFinite(this._routeFinalFuelWeight)) {
+            return this._routeFinalFuelWeight;
+        }
+        else if (isFinite(this._routeFinalFuelTime)) {
+            return this.getTotalTripFuelCons() / this.getTotalTripTime() * this._routeFinalFuelTime;
+        }
+        return NaN;
+    }
+    getRouteFinalFuelTime() {
+        if (isFinite(this._routeFinalFuelTime)) {
+            return this._routeFinalFuelTime;
+        }
+        else if (isFinite(this._routeFinalFuelWeight)) {
+            return this.getTotalTripTime() / this.getTotalTripFuelCons() * this._routeFinalFuelWeight;
+        }
+        return NaN;
+    }
+    async trySetRouteFinalFuel(s) {
+        if (s) {
+            let rteFinalWeight = parseFloat(s.split("/")[0]);
+            let rteFinalTime = FMCMainDisplay.hhmmToSeconds(s.split("/")[1]);
+            if (isFinite(rteFinalWeight)) {
+                this._routeFinalFuelWeight = rteFinalWeight;
+                this._routeFinalFuelTime = NaN;
+                return true;
+            }
+            else if (isFinite(rteFinalTime)) {
+                this._routeFinalFuelWeight = NaN;
+                this._routeFinalFuelTime = rteFinalTime;
+                return true;
+            }
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    getRouteReservedWeight() {
+        if (isFinite(this._routeReservedWeight)) {
+            return this._routeReservedWeight;
+        }
+        else {
+            return this._routeReservedPercent * this.blockFuel / 100;
+        }
+    }
+    getRouteReservedPercent() {
+        if (isFinite(this._routeReservedWeight) && isFinite(this.blockFuel)) {
+            return this._routeReservedWeight / this.blockFuel * 100;
+        }
+        return this._routeReservedPercent;
+    }
+    trySetRouteReservedFuel(s) {
+        if (s) {
+            let rteRsvWeight = parseFloat(s.split("/")[0]);
+            let rteRsvPercent = parseFloat(s.split("/")[1]);
+            if (isFinite(rteRsvWeight)) {
+                this._routeReservedWeight = rteRsvWeight;
+                this._routeReservedPercent = 0;
+                return true;
+            }
+            else if (isFinite(rteRsvPercent)) {
+                this._routeReservedWeight = NaN;
+                this._routeReservedPercent = rteRsvPercent;
+                return true;
+            }
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    updateTakeOffTrim() {
+        let d = (this.zeroFuelWeightMassCenter - 13) / (33 - 13);
+        d = Math.min(Math.max(d, -0.5), 1);
+        let dW = (this.getWeight(true) - 400) / (800 - 400);
+        dW = Math.min(Math.max(dW, 0), 1);
+        let minTrim = 3.5 * dW + 1.5 * (1 - dW);
+        let maxTrim = 8.6 * dW + 4.3 * (1 - dW);
+        this.takeOffTrim = minTrim * d + maxTrim * (1 - d);
+    }
+    getTakeOffFlap() {
+        return this._takeOffFlap;
+    }
+    setTakeOffFlap(s) {
+        let value = Number.parseInt(s);
+        if (isFinite(value)) {
+            if (value >= 0 && value <= 30) {
+                this._takeOffFlap = value;
+                return true;
+            }
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    getZeroFuelWeight(useLbs = false) {
+        if (useLbs) {
+            return this.zeroFuelWeight * 2.204623;
+        }
+        return this.zeroFuelWeight;
+    }
+    getApproachWeight(useLbs = false) {
+        return this.getWeight(useLbs) * 0.25 + this.getZeroFuelWeight(useLbs) * 0.75;
+    }
+    setZeroFuelWeight(s, callback = EmptyCallback.Boolean, useLbs = false) {
+        let value = parseFloat(s);
+        if (isFinite(value)) {
+            if (!useLbs) {
+                value = value * 2.204623;
+            }
+            Coherent.call("ZFW_VALUE_SET", value * 1000);
+            this.updateFuelVars();
+            this.updateTakeOffTrim();
+            return callback(true);
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        callback(false);
+    }
+    setZeroFuelCG(s, callback = EmptyCallback.Boolean) {
+        let value = parseFloat(s);
+        if (isFinite(value) && value > 0 && value < 100) {
+            this.zeroFuelWeightMassCenter = value;
+            this.updateTakeOffTrim();
+            return callback(true);
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        callback(false);
+    }
+    async trySetZeroFuelWeightZFWCG(s, useLbs = false) {
+        let zfw = NaN;
+        let zfwcg = NaN;
+        if (s) {
+            let sSplit = s.split("/");
+            zfw = parseFloat(sSplit[0]);
+            if (!useLbs) {
+                zfw = zfw * 2.204623;
+            }
+            zfwcg = parseFloat(sSplit[1]);
+        }
+        if (isFinite(zfw) || isFinite(zfwcg) && zfw > 0 && zfwcg > 0) {
+            if (isFinite(zfw)) {
+                Coherent.call("ZFW_VALUE_SET", zfw * 1000);
+                this.updateFuelVars();
+            }
+            if (isFinite(zfwcg)) {
+                this.zeroFuelWeightMassCenter = zfwcg;
+            }
+            this.updateTakeOffTrim();
+            this.updateCleanTakeOffSpeed();
+            this.updateCleanApproachSpeed();
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    getBlockFuel(useLbs = false) {
+        if (useLbs) {
+            return this.blockFuel * 2.204623;
+        }
+        return this.blockFuel;
+    }
+    trySetBlockFuel(s, useLbs = false) {
+        let value = parseFloat(s);
+        if (isFinite(value)) {
+            if (useLbs) {
+                value = value / 2.204623;
+            }
+            this.blockFuel = value;
+            this.updateTakeOffTrim();
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    getFuelReserves() {
+        return this._fuelReserves;
+    }
+    setFuelReserves(s, useLbs = false) {
+        let value = parseFloat(s);
+        if (isFinite(value)) {
+            if (value >= 0) {
+                if (value < this.getBlockFuel(useLbs)) {
+                    this._fuelReserves = value;
+                    return true;
+                }
+            }
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    getWeight(useLbs = false) {
+        let w = this.zeroFuelWeight + this.blockFuel;
+        if (useLbs) {
+            w *= 2.204623;
+        }
+        return w;
+    }
+    getCurrentWeight(useLbs = false) {
+        return new Promise(resolve => {
+            Coherent.call("TOTAL_WEIGHT_GET").then(v => {
+                if (!useLbs) {
+                    v /= 2.204623;
+                }
+                resolve(v);
+            });
+        });
+    }
+    setWeight(a, callback = EmptyCallback.Boolean, useLbs = false) {
+        let v = NaN;
+        if (typeof (a) === "number") {
+            v = a;
+        }
+        else if (typeof (a) === "string") {
+            v = parseFloat(a);
+        }
+        if (isFinite(v)) {
+            if (useLbs) {
+                v = v / 2.204623;
+            }
+            if (isFinite(this.zeroFuelWeight)) {
+                if (v - this.zeroFuelWeight > 0) {
+                    this.blockFuel = v - this.zeroFuelWeight;
+                    return callback(true);
+                }
+            }
+            else {
+                this.showErrorMessage("ZFW NOT SET");
+                return callback(false);
+            }
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return callback(false);
+    }
+    async trySetTakeOffWeightLandingWeight(s) {
+        let tow = NaN;
+        let lw = NaN;
+        if (s) {
+            let sSplit = s.split("/");
+            tow = parseFloat(sSplit[0]);
+            lw = parseFloat(sSplit[1]);
+        }
+        if (isFinite(tow) || isFinite(lw)) {
+            if (isFinite(tow)) {
+                this.takeOffWeight = tow;
+            }
+            if (isFinite(lw)) {
+                this.landingWeight = lw;
+            }
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    async trySetAverageWind(s) {
+        let value = parseFloat(s);
+        if (isFinite(value)) {
+            this.averageWind = value;
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    setPerfCrzWind(s) {
+        let heading = NaN;
+        let speed = NaN;
+        if (s) {
+            let sSplit = s.split("/");
+            heading = parseFloat(sSplit[0]);
+            speed = parseFloat(sSplit[1]);
+        }
+        if ((isFinite(heading) && heading >= 0 && heading < 360) || (isFinite(speed) && speed > 0)) {
+            if (isFinite(heading)) {
+                this.perfCrzWindHeading = heading;
+            }
+            if (isFinite(speed)) {
+                this.perfCrzWindSpeed = speed;
+            }
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    trySetPreSelectedClimbSpeed(s) {
+        let v = parseFloat(s);
+        if (isFinite(v)) {
+            this.preSelectedClbSpeed = v;
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    trySetPreSelectedCruiseSpeed(s) {
+        let v = parseFloat(s);
+        if (isFinite(v)) {
+            this.preSelectedCrzSpeed = v;
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    trySetPreSelectedDescentSpeed(s) {
+        let v = parseFloat(s);
+        if (isFinite(v)) {
+            this.preSelectedDesSpeed = v;
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    setPerfApprQNH(s) {
+        let value = parseFloat(s);
+        if (isFinite(value)) {
+            this.perfApprQNH = value;
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    setPerfApprTemp(s) {
+        let value = parseFloat(s);
+        if (isFinite(value) && value > -270 && value < 150) {
+            this.perfApprTemp = value;
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    setPerfApprWind(s) {
+        let heading = NaN;
+        let speed = NaN;
+        if (s) {
+            let sSplit = s.split("/");
+            heading = parseFloat(sSplit[0]);
+            speed = parseFloat(sSplit[1]);
+        }
+        if ((isFinite(heading) && heading >= 0 && heading < 360) || (isFinite(speed) && speed > 0)) {
+            if (isFinite(heading)) {
+                this.perfApprWindHeading = heading;
+            }
+            if (isFinite(speed)) {
+                this.perfApprWindSpeed = speed;
+            }
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    setPerfApprTransAlt(s) {
+        let value = parseFloat(s);
+        if (isFinite(value) && value > 0 && value < 60000) {
+            this.perfApprTransAlt = value;
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    getVApp() {
+        if (isFinite(this.vApp)) {
+            return this.vApp;
+        }
+        let windComp = SimVar.GetSimVarValue("AIRCRAFT WIND Z", "knots") / 3;
+        windComp = Math.max(windComp, 5);
+        return this.getVLS() + windComp;
+    }
+    setPerfApprVApp(s) {
+        if (s === FMCMainDisplay.clrValue) {
+            this.vApp = NaN;
+        }
+        let value = parseFloat(s);
+        if (isFinite(value) && value > 0) {
+            this.vApp = value;
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    getVLS() {
+        let flapsHandleIndex = Simplane.getFlapsHandleIndex();
+        if (flapsHandleIndex === 4) {
+            let dWeight = (this.getWeight() - 61.4) / (82.5 - 61.4);
+            return 141 + 20 * dWeight;
+        }
+        else {
+            let dWeight = (this.getWeight() - 61.4) / (82.5 - 61.4);
+            return 146 + 21 * dWeight;
+        }
+    }
+    setPerfApprMDA(s) {
+        let value = parseFloat(s);
+        if (isFinite(value)) {
+            this.perfApprMDA = value;
+            SimVar.SetSimVarValue("L:AIRLINER_MINIMUM_DESCENT_ALTITUDE", "number", this.perfApprMDA);
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    setPerfApprDH(s) {
+        let value = parseFloat(s);
+        if (isFinite(value)) {
+            this.perfApprDH = value;
+            SimVar.SetSimVarValue("L:AIRLINER_DECISION_HEIGHT", "number", this.perfApprDH);
+            return true;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    getIsFlying() {
+        return this.currentFlightPhase >= FlightPhase.FLIGHT_PHASE_TAKEOFF;
+    }
+    async tryGoInApproachPhase() {
+        if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_CLIMB) {
+            this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_APPROACH;
+            Coherent.call("GENERAL_ENG_THROTTLE_MANAGED_MODE_SET", ThrottleMode.AUTO);
+            return true;
+        }
+        if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_CRUISE) {
+            this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_APPROACH;
+            Coherent.call("GENERAL_ENG_THROTTLE_MANAGED_MODE_SET", ThrottleMode.AUTO);
+            return true;
+        }
+        if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_DESCENT) {
+            this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_APPROACH;
+            Coherent.call("GENERAL_ENG_THROTTLE_MANAGED_MODE_SET", ThrottleMode.AUTO);
+            return true;
+        }
+        if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_APPROACH) {
+            return true;
+        }
+        return false;
+    }
+    checkUpdateFlightPhase() {
+        let airSpeed = SimVar.GetSimVarValue("AIRSPEED TRUE", "knots");
+        if (airSpeed > 10) {
+            if (this.currentFlightPhase === 0) {
+                this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_TAKEOFF;
+            }
+            if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_TAKEOFF) {
+                let enterClimbPhase = false;
+                let agl = Simplane.getAltitude();
+                let altValue = isFinite(this.thrustReductionAltitude) ? this.thrustReductionAltitude : 1500;
+                if (agl > altValue) {
+                    this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_CLIMB;
+                    enterClimbPhase = true;
+                }
+                if (enterClimbPhase) {
+                    let origin = this.flightPlanManager.getOrigin();
+                    if (origin) {
+                        origin.altitudeWasReached = Simplane.getAltitude();
+                        origin.timeWasReached = SimVar.GetGlobalVarValue("LOCAL TIME", "seconds");
+                        origin.fuelWasReached = SimVar.GetSimVarValue("FUEL TOTAL QUANTITY", "gallons") * SimVar.GetSimVarValue("FUEL WEIGHT PER GALLON", "kilograms") / 1000;
+                    }
+                }
+            }
+            if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_CLIMB) {
+                let altitude = SimVar.GetSimVarValue("PLANE ALTITUDE", "feet");
+                let cruiseFlightLevel = this.cruiseFlightLevel * 100;
+                if (isFinite(cruiseFlightLevel)) {
+                    if (altitude >= 0.96 * cruiseFlightLevel) {
+                        this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_CRUISE;
+                        Coherent.call("GENERAL_ENG_THROTTLE_MANAGED_MODE_SET", ThrottleMode.AUTO);
+                    }
+                }
+            }
+            if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_CRUISE) {
+                let altitude = SimVar.GetSimVarValue("PLANE ALTITUDE", "feet");
+                let cruiseFlightLevel = this.cruiseFlightLevel * 100;
+                if (isFinite(cruiseFlightLevel)) {
+                    if (altitude < 0.9 * cruiseFlightLevel) {
+                        this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_DESCENT;
+                        Coherent.call("GENERAL_ENG_THROTTLE_MANAGED_MODE_SET", ThrottleMode.AUTO);
+                    }
+                    let destination = this.flightPlanManager.getDestination();
+                    if (destination) {
+                        let lat = SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude");
+                        let long = SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude");
+                        let planeLla = new LatLongAlt(lat, long);
+                        let dist = Avionics.Utils.computeGreatCircleDistance(destination.infos.coordinates, planeLla);
+                        if (dist < cruiseFlightLevel / 6076 * 20) {
+                            this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_DESCENT;
+                            Coherent.call("GENERAL_ENG_THROTTLE_MANAGED_MODE_SET", ThrottleMode.AUTO);
+                        }
+                    }
+                }
+            }
+            if (this.currentFlightPhase != FlightPhase.FLIGHT_PHASE_APPROACH) {
+                if (this.flightPlanManager.decelWaypoint) {
+                    let lat = SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude");
+                    let long = SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude");
+                    let planeLla = new LatLongAlt(lat, long);
+                    let dist = Avionics.Utils.computeGreatCircleDistance(this.flightPlanManager.decelWaypoint.infos.coordinates, planeLla);
+                    if (dist < 3) {
+                        this.tryGoInApproachPhase();
+                    }
+                }
+            }
+            if (this.currentFlightPhase != FlightPhase.FLIGHT_PHASE_APPROACH) {
+                let destination = this.flightPlanManager.getDestination();
+                if (destination) {
+                    let lat = SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude");
+                    let long = SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude");
+                    let planeLla = new LatLongAlt(lat, long);
+                    let dist = Avionics.Utils.computeGreatCircleDistance(destination.infos.coordinates, planeLla);
+                    if (dist < 20) {
+                        this.tryGoInApproachPhase();
+                    }
+                }
+            }
+        }
+        if (SimVar.GetSimVarValue("L:AIRLINER_FLIGHT_PHASE", "number") != this.currentFlightPhase) {
+            SimVar.SetSimVarValue("L:AIRLINER_FLIGHT_PHASE", "number", this.currentFlightPhase);
+            this.onFlightPhaseChanged();
+        }
+    }
+    onFlightPhaseChanged() {
+    }
+    connectIlsFrequency(_freq) {
+        if (_freq >= 108 && _freq <= 111.95 && RadioNav.isHz50Compliant(_freq)) {
+            switch (this.radioNav.mode) {
+                case NavMode.FOUR_SLOTS:
+                    {
+                        this.ilsFrequency = _freq;
+                        break;
+                    }
+                case NavMode.TWO_SLOTS:
+                    {
+                        this.vor1Frequency = _freq;
+                        break;
+                    }
+            }
+            this.connectIls();
+            return true;
+        }
+        return false;
+    }
+    connectIls() {
+        if (this.isRadioNavActive()) {
+            return;
+        }
+        if (this._lockConnectIls) {
+            return;
+        }
+        this._lockConnectIls = true;
+        setTimeout(() => {
+            this._lockConnectIls = false;
+        }, 1000);
+        switch (this.radioNav.mode) {
+            case NavMode.FOUR_SLOTS:
+                {
+                    if (Math.abs(this.radioNav.getILSActiveFrequency(1) - this.ilsFrequency) > 0.005) {
+                        this.radioNav.setILSActiveFrequency(1, this.ilsFrequency);
+                    }
+                    break;
+                }
+            case NavMode.TWO_SLOTS:
+                {
+                    if (Math.abs(this.radioNav.getVORActiveFrequency(1) - this.vor1Frequency) > 0.005) {
+                        this.radioNav.setVORActiveFrequency(1, this.vor1Frequency);
+                    }
+                    break;
+                }
+            default:
+                console.error("Unknown RadioNav operating mode");
+                break;
+        }
+    }
+    setIlsFrequency(s) {
+        if (s === FMCMainDisplay.clrValue) {
+            this.ilsFrequency = 0;
+            return true;
+        }
+        let v = parseFloat(s);
+        if (isFinite(v)) {
+            let freq = Math.round(v * 100) / 100;
+            if (this.connectIlsFrequency(freq))
+                return true;
+            this.showErrorMessage("OUT OF RANGE");
+            return false;
+        }
+        this.showErrorMessage(this.defaultInputErrorMessage);
+        return false;
+    }
+    initRadioNav(_boot) {
+        if (this.isPrimary) {
+            console.log("Init RadioNav");
+            {
+                if (_boot) {
+                    this.vhf1Frequency = this.radioNav.getVHFActiveFrequency(this.instrumentIndex, 1);
+                    this.vhf2Frequency = this.radioNav.getVHFActiveFrequency(this.instrumentIndex, 2);
+                }
+                else {
+                    if (Math.abs(this.radioNav.getVHFActiveFrequency(this.instrumentIndex, 1) - this.vhf1Frequency) > 0.005) {
+                        this.radioNav.setVHFActiveFrequency(this.instrumentIndex, 1, this.vhf1Frequency);
+                    }
+                    if (Math.abs(this.radioNav.getVHFActiveFrequency(this.instrumentIndex, 2) - this.vhf2Frequency) > 0.005) {
+                        this.radioNav.setVHFActiveFrequency(this.instrumentIndex, 2, this.vhf2Frequency);
+                    }
+                }
+            }
+            {
+                if (Math.abs(this.radioNav.getVORActiveFrequency(1) - this.vor1Frequency) > 0.005) {
+                    this.radioNav.setVORActiveFrequency(1, this.vor1Frequency);
+                }
+                if (this.vor1Course >= 0) {
+                    SimVar.SetSimVarValue("K:VOR1_SET", "number", this.vor1Course);
+                }
+                this.connectIls();
+            }
+            {
+                if (Math.abs(this.radioNav.getVORActiveFrequency(2) - this.vor2Frequency) > 0.005) {
+                    this.radioNav.setVORActiveFrequency(2, this.vor2Frequency);
+                }
+                if (this.vor2Course >= 0) {
+                    SimVar.SetSimVarValue("K:VOR2_SET", "number", this.vor2Course);
+                }
+                if (Math.abs(this.radioNav.getILSActiveFrequency(2) - 0) > 0.005) {
+                    this.radioNav.setILSActiveFrequency(2, 0);
+                }
+            }
+            {
+                if (_boot) {
+                    this.adf1Frequency = this.radioNav.getADFActiveFrequency(1);
+                    this.adf2Frequency = this.radioNav.getADFActiveFrequency(2);
+                }
+                else {
+                    if (Math.abs(this.radioNav.getADFActiveFrequency(1) - this.adf1Frequency) > 0.005) {
+                        SimVar.SetSimVarValue("K:ADF_COMPLETE_SET", "Frequency ADF BCD32", Avionics.Utils.make_adf_bcd32(this.adf1Frequency * 1000)).then(() => {
+                        });
+                    }
+                    if (Math.abs(this.radioNav.getADFActiveFrequency(2) - this.adf2Frequency) > 0.005) {
+                        SimVar.SetSimVarValue("K:ADF2_COMPLETE_SET", "Frequency ADF BCD32", Avionics.Utils.make_adf_bcd32(this.adf2Frequency * 1000)).then(() => {
+                        });
+                    }
+                }
+            }
+            {
+                if (_boot) {
+                    this.atc1Frequency = SimVar.GetSimVarValue("TRANSPONDER CODE:1", "number");
+                }
+                else {
+                    if (this.atc1Frequency > 0) {
+                        SimVar.SetSimVarValue("K:XPNDR_SET", "Frequency BCD16", Avionics.Utils.make_xpndr_bcd16(this.atc1Frequency));
+                    }
+                    else {
+                        this.atc1Frequency = SimVar.GetSimVarValue("TRANSPONDER CODE:1", "number");
+                    }
+                }
+            }
+        }
+    }
+    updateRadioNavState() {
+        if (this.isPrimary) {
+            let radioNavOn = this.isRadioNavActive();
+            if (radioNavOn != this._radioNavOn) {
+                this._radioNavOn = radioNavOn;
+                if (!radioNavOn)
+                    this.initRadioNav(false);
+                if (this.refreshPageCallback)
+                    this.refreshPageCallback();
+            }
+            let apNavIndex = 1;
+            let gpsDriven = true;
+            if (this.canSwitchToNav()) {
+                let navid = 0;
+                let ils = this.radioNav.getBestILSBeacon();
+                if (ils.id > 0) {
+                    navid = ils.id;
+                }
+                else {
+                    let vor = this.radioNav.getBestVORBeacon();
+                    if (vor.id > 0) {
+                        navid = vor.id;
+                    }
+                }
+                if (navid > 0) {
+                    apNavIndex = navid;
+                    let hasFlightplan = Simplane.getAutopilotGPSActive();
+                    let apprCaptured = Simplane.getAutoPilotAPPRCaptured();
+                    if (apprCaptured || !hasFlightplan) {
+                        gpsDriven = false;
+                    }
+                }
+            }
+            if (apNavIndex != this._apNavIndex) {
+                SimVar.SetSimVarValue("K:AP_NAV_SELECT_SET", "number", apNavIndex);
+                this._apNavIndex = apNavIndex;
+            }
+            let curState = SimVar.GetSimVarValue("GPS DRIVES NAV1", "Bool");
+            if (curState != gpsDriven) {
+                SimVar.SetSimVarValue("K:TOGGLE_GPS_DRIVES_NAV1", "Bool", 0);
+            }
+        }
+    }
+    canSwitchToNav() {
+        if (!this._canSwitchToNav) {
+            let altitude = Simplane.getAltitudeAboveGround();
+            if (altitude >= 500) {
+                this._canSwitchToNav = true;
+            }
+        }
+        if (this._canSwitchToNav) {
+            if (!this.needApproachToSwitchToNav) {
+                return true;
+            }
+            else {
+                let apprHold = SimVar.GetSimVarValue("AUTOPILOT APPROACH HOLD", "Bool");
+                if (apprHold) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    isRadioNavActive() {
+        return this.radioNav.getRADIONAVActive((this.isPrimary) ? 1 : 2);
+    }
+    get vhf1Frequency() { return this._vhf1Frequency; }
+    get vhf2Frequency() { return this._vhf2Frequency; }
+    get vor1Frequency() { return this._vor1Frequency; }
+    get vor1Course() { return this._vor1Course; }
+    get vor2Frequency() { return this._vor2Frequency; }
+    get vor2Course() { return this._vor2Course; }
+    get ilsFrequency() { return this._ilsFrequency; }
+    get ilsCourse() { return this._ilsCourse; }
+    get adf1Frequency() { return this._adf1Frequency; }
+    get adf2Frequency() { return this._adf2Frequency; }
+    get rcl1Frequency() { return this._rcl1Frequency; }
+    get pre2Frequency() { return this._pre2Frequency; }
+    get atc1Frequency() { return this._atc1Frequency; }
+    set vhf1Frequency(_frq) { this._vhf1Frequency = _frq; }
+    set vhf2Frequency(_frq) { this._vhf2Frequency = _frq; }
+    set vor1Frequency(_frq) { this._vor1Frequency = _frq; SimVar.SetSimVarValue("L:FMC_VOR_FREQUENCY:1", "Hz", _frq * 1000000); }
+    set vor1Course(_crs) { this._vor1Course = _crs; }
+    set vor2Frequency(_frq) { this._vor2Frequency = _frq; SimVar.SetSimVarValue("L:FMC_VOR_FREQUENCY:2", "Hz", _frq * 1000000); }
+    set vor2Course(_crs) { this._vor2Course = _crs; }
+    set ilsFrequency(_frq) { this._ilsFrequency = _frq; }
+    set ilsCourse(_crs) { this._ilsCourse = _crs; }
+    set adf1Frequency(_frq) { this._adf1Frequency = _frq; }
+    set adf2Frequency(_frq) { this._adf2Frequency = _frq; }
+    set rcl1Frequency(_frq) { this._rcl1Frequency = _frq; }
+    set pre2Frequency(_frq) { this._pre2Frequency = _frq; }
+    set atc1Frequency(_frq) { this._atc1Frequency = _frq; }
+    Init() {
+        super.Init();
+        this.dataManager = new FMCDataManager(this);
+        this.tempCurve = new Avionics.Curve();
+        this.tempCurve.interpolationFunction = Avionics.CurveTool.NumberInterpolation;
+        this.tempCurve.add(-10 * 3.28084, 21.50);
+        this.tempCurve.add(0 * 3.28084, 15.00);
+        this.tempCurve.add(10 * 3.28084, 8.50);
+        this.tempCurve.add(20 * 3.28084, 2.00);
+        this.tempCurve.add(30 * 3.28084, -4.49);
+        this.tempCurve.add(40 * 3.28084, -10.98);
+        this.tempCurve.add(50 * 3.28084, -17.47);
+        this.tempCurve.add(60 * 3.28084, -23.96);
+        this.tempCurve.add(70 * 3.28084, -30.45);
+        this.tempCurve.add(80 * 3.28084, -36.94);
+        this.tempCurve.add(90 * 3.28084, -43.42);
+        this.tempCurve.add(100 * 3.28084, -49.90);
+        this.tempCurve.add(150 * 3.28084, -56.50);
+        this.tempCurve.add(200 * 3.28084, -56.50);
+        this.tempCurve.add(250 * 3.28084, -51.60);
+        this.tempCurve.add(300 * 3.28084, -46.64);
+        this.tempCurve.add(400 * 3.28084, -22.80);
+        this.tempCurve.add(500 * 3.28084, -2.5);
+        this.tempCurve.add(600 * 3.28084, -26.13);
+        this.tempCurve.add(700 * 3.28084, -53.57);
+        this.tempCurve.add(800 * 3.28084, -74.51);
+        let mainFrame = this.getChildById("Electricity");
+        if (mainFrame == null)
+            mainFrame = this;
+        this.generateHTMLLayout(mainFrame);
+        this._titleElement = this.getChildById("title");
+        this._pageCurrentElement = this.getChildById("page-current");
+        this._pageCountElement = this.getChildById("page-count");
+        this._labelElements = [];
+        this._lineElements = [];
+        for (let i = 0; i < 6; i++) {
+            this._labelElements[i] = [
+                this.getChildById("label-" + i + "-left"),
+                this.getChildById("label-" + i + "-right"),
+                this.getChildById("label-" + i + "-center")
+            ];
+            this._lineElements[i] = [
+                this.getChildById("line-" + i + "-left"),
+                this.getChildById("line-" + i + "-right"),
+                this.getChildById("line-" + i + "-center")
+            ];
+        }
+        this._inOutElement = this.getChildById("in-out");
+        this.onMenu = () => { FMCMainDisplayPages.MenuPage(this); };
+        this.onLetterInput = (l) => {
+            if (this.inOut === FMCMainDisplay.clrValue) {
+                this.inOut = "";
+            }
+            if (this.isDisplayingErrorMessage) {
+                this.inOut = this.lastUserInput;
+                this.isDisplayingErrorMessage = false;
+            }
+            this.inOut += l;
+        };
+        this.onSp = () => {
+            if (this.inOut === FMCMainDisplay.clrValue) {
+                this.inOut = "";
+            }
+            if (this.isDisplayingErrorMessage) {
+                this.inOut = this.lastUserInput;
+                this.isDisplayingErrorMessage = false;
+            }
+            this.inOut += " ";
+        };
+        this.onDel = () => { if (this.inOut.length > 0) {
+            this.inOut = this.inOut.slice(0, this.inOut.length - 1);
+        } };
+        this.onDiv = () => {
+            if (this.inOut === FMCMainDisplay.clrValue) {
+                this.inOut = "";
+            }
+            if (this.isDisplayingErrorMessage) {
+                this.inOut = this.lastUserInput;
+                this.isDisplayingErrorMessage = false;
+            }
+            this.inOut += "/";
+        };
+        this.onClr = () => {
+            if (this.inOut === "") {
+                this.inOut = FMCMainDisplay.clrValue;
+            }
+            else if (this.inOut === FMCMainDisplay.clrValue) {
+                this.inOut = "";
+            }
+            else {
+                if (this.isDisplayingErrorMessage) {
+                    this.inOut = this.lastUserInput;
+                    this.isDisplayingErrorMessage = false;
+                }
+                else if (this.inOut.length > 0) {
+                    this.inOut = this.inOut.substr(0, this.inOut.length - 1);
+                }
+            }
+        };
+        this.onClrLong = () => {
+            if (this.inOut === "") {
+                this.inOut = FMCMainDisplay.clrValue;
+            }
+            else if (this.inOut === FMCMainDisplay.clrValue) {
+                this.inOut = "";
+            }
+            else {
+                if (this.isDisplayingErrorMessage) {
+                    this.inOut = this.lastUserInput;
+                    this.isDisplayingErrorMessage = false;
+                }
+                else if (this.inOut.length > 0) {
+                    this.inOut = "";
+                }
+            }
+        };
+        SimVar.SetSimVarValue("L:FLIGHTPLAN_USE_DECEL_WAYPOINT", "number", 1);
+        SimVar.SetSimVarValue("L:AIRLINER_TO_FLEX_TEMP", "Number", this.perfTOTemp);
+        this.flightPlanManager.onCurrentGameFlightLoaded(() => {
+            this.flightPlanManager.updateFlightPlan(() => {
+                this.flightPlanManager.updateCurrentApproach(() => {
+                    let frequency = this.flightPlanManager.getApproachNavFrequency();
+                    if (isFinite(frequency)) {
+                        let freq = Math.round(frequency * 100) / 100;
+                        if (this.connectIlsFrequency(freq)) {
+                            SimVar.SetSimVarValue("L:FLIGHTPLAN_APPROACH_ILS", "number", freq);
+                            let approach = this.flightPlanManager.getApproach();
+                            if (approach && approach.name && approach.name.indexOf("ILS") !== -1) {
+                                let runway = this.flightPlanManager.getApproachRunway();
+                                if (runway) {
+                                    SimVar.SetSimVarValue("L:FLIGHTPLAN_APPROACH_COURSE", "number", runway.direction);
+                                }
+                            }
+                        }
+                    }
+                    if (Simplane.getAltitude() > 1000) {
+                        if (this.flightPlanManager.getWaypoints().length === 2) {
+                            Coherent.call("GET_RUNWAY_ARRIVAL").then((runwayArrivalIndex) => {
+                                let destination = this.flightPlanManager.getDestination();
+                                if (destination.infos instanceof AirportInfo) {
+                                    let runwayArrival = destination.infos.unsortedOneWayRunways[runwayArrivalIndex];
+                                    if (runwayArrival) {
+                                        let ilsApproachIndex = destination.infos.approaches.findIndex(approach => {
+                                            return approach.name.indexOf("ILS") != -1 && approach.name.indexOf(runwayArrival.designation) != -1;
+                                        });
+                                        if (ilsApproachIndex) {
+                                            this.setApproachIndex(ilsApproachIndex, () => {
+                                                this.insertTemporaryFlightPlan();
+                                            });
+                                        }
+                                    }
+                                }
+                            });
+                        }
+                    }
+                });
+                if (this.flightPlanManager.getWaypoints().length > 0) {
+                    this.costIndex = 100;
+                }
+                this.onFMCFlightPlanLoaded();
+                let callback = () => {
+                    this.flightPlanManager.createNewFlightPlan();
+                    let cruiseAlt = Math.floor(this.flightPlanManager.cruisingAltitude / 100);
+                    console.log("FlightPlan Cruise Override. Cruising at FL" + cruiseAlt + " instead of default FL" + this.cruiseFlightLevel);
+                    if (cruiseAlt > 0)
+                        this.cruiseFlightLevel = cruiseAlt;
+                };
+                let arrivalIndex = this.flightPlanManager.getArrivalProcIndex();
+                if (arrivalIndex >= 0) {
+                    this.flightPlanManager.setArrivalProcIndex(arrivalIndex, callback);
+                }
+                else {
+                    callback();
+                }
+                this.recalculateTHRRedAccTransAlt();
+            });
+        });
+        this.recalculateTHRRedAccTransAlt();
+    }
+    onFMCFlightPlanLoaded() {
+    }
+    recalculateTHRRedAccTransAlt() {
+        let origin = this.flightPlanManager.getOrigin();
+        if (origin) {
+            if (isFinite(origin.altitudeinFP)) {
+                let altitude = Math.round(origin.altitudeinFP / 10) * 10;
+                this.thrustReductionAltitude = altitude + 1500;
+                this.accelerationAltitude = altitude + 1500;
+                if (origin.infos instanceof AirportInfo) {
+                    this.transitionAltitude = origin.infos.transitionAltitude;
+                }
+                SimVar.SetSimVarValue("L:AIRLINER_THR_RED_ALT", "Number", this.thrustReductionAltitude);
+                SimVar.SetSimVarValue("L:AIRLINER_ACC_ALT", "Number", this.accelerationAltitude);
+            }
+        }
+        let destination = this.flightPlanManager.getDestination();
+        if (destination) {
+            if (destination.infos instanceof AirportInfo) {
+                this.perfApprTransAlt = destination.infos.transitionAltitude;
+            }
+        }
+    }
+    onPowerOn() {
+        super.onPowerOn();
+        this.updateFuelVars();
+        let gpsDriven = SimVar.GetSimVarValue("GPS DRIVES NAV1", "Bool");
+        if (!gpsDriven)
+            SimVar.SetSimVarValue("K:TOGGLE_GPS_DRIVES_NAV1", "Bool", 0);
+        this.initRadioNav(true);
+    }
+    onShutDown() {
+        super.onShutDown();
+        this.clearVSpeeds();
+    }
+    getFuelVarsUpdatedGrossWeight(useLbs = false) {
+        if (!useLbs) {
+            return this._fuelVarsUpdatedGrossWeight;
+        }
+        return this._fuelVarsUpdatedGrossWeight * 2.204623;
+    }
+    getFuelVarsUpdatedTripCons(useLbs = false) {
+        if (!useLbs) {
+            return this._fuelVarsUpdatedTripCons;
+        }
+        return this._fuelVarsUpdatedTripCons * 2.204623;
+    }
+    updateFuelVars() {
+        return new Promise(resolve => {
+            this.getCurrentWeight().then(w => {
+                let grossWeight = w / 1000;
+                if (Math.floor(this._fuelVarsUpdatedGrossWeight) != Math.floor(grossWeight)) {
+                    this._fuelVarsUpdatedGrossWeight = grossWeight;
+                    this.blockFuel = SimVar.GetSimVarValue("FUEL TOTAL QUANTITY", "gallons") * SimVar.GetSimVarValue("FUEL WEIGHT PER GALLON", "kilograms") / 1000;
+                    this.zeroFuelWeight = this._fuelVarsUpdatedGrossWeight - this.blockFuel;
+                    this.zeroFuelWeightMassCenter = SimVar.GetSimVarValue("CG PERCENT", "percent");
+                    this.updateVSpeeds();
+                    let waypointsNumber = SimVar.GetSimVarValue("C:fs9gps:FlightPlanWaypointsNumber", "number", this.instrumentIdentifier);
+                    if (waypointsNumber > 1) {
+                        SimVar.SetSimVarValue("C:fs9gps:FlightPlanWaypointIndex", "number", waypointsNumber - 1).then(() => {
+                            this._fuelVarsUpdatedTripCons = SimVar.GetSimVarValue("C:fs9gps:FlightPlanWaypointEstimatedFuelConsumption", "gallons") * SimVar.GetSimVarValue("FUEL WEIGHT PER GALLON", "kilograms") / 1000;
+                        });
+                        resolve();
+                    }
+                    else {
+                        resolve();
+                    }
+                }
+                else {
+                    resolve();
+                }
+            });
+        });
+    }
+    updateVSpeeds() {
+        if (!this.customV1Speed && !this.customVRSpeed && !this.customV2Speed && !this.wasTurnedOff()) {
+            this._computeV1Speed();
+            this._computeVRSpeed();
+            this._computeV2Speed();
+        }
+    }
+    clearVSpeeds() {
+        this.v1Speed = undefined;
+        this.vRSpeed = undefined;
+        this.v2Speed = undefined;
+        SimVar.SetSimVarValue("L:AIRLINER_V1_SPEED", "Knots", 0);
+        SimVar.SetSimVarValue("L:AIRLINER_VR_SPEED", "Knots", 0);
+        SimVar.SetSimVarValue("L:AIRLINER_V2_SPEED", "Knots", 0);
+        this.customV1Speed = false;
+        this.customVRSpeed = false;
+        this.customV2Speed = false;
+    }
+    onUpdate(_deltaTime) {
+        super.onUpdate(_deltaTime);
+        if (this._debug++ > 180) {
+            this._debug = 0;
+        }
+        this.checkUpdateFlightPhase();
+        this._checkFlightPlan--;
+        if (this._checkFlightPlan <= 0) {
+            this._checkFlightPlan = 60;
+            this.flightPlanManager.updateFlightPlan();
+            this.flightPlanManager.updateCurrentApproach();
+        }
+        this._checkUpdateFuel -= _deltaTime / 1000;
+        if (this._checkUpdateFuel <= 0) {
+            this._checkUpdateFuel = 5;
+            this.updateFuelVars();
+        }
+        if (this.pageUpdate) {
+            this.pageUpdate();
+        }
+        if (SimVar.GetSimVarValue("L:FMC_UPDATE_CURRENT_PAGE", "number") === 1) {
+            SimVar.SetSimVarValue("L:FMC_UPDATE_CURRENT_PAGE", "number", 0);
+            if (this.refreshPageCallback) {
+                this.refreshPageCallback();
+            }
+        }
+        if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_APPROACH) {
+            SimVar.SetSimVarValue("L:AIRLINER_MANAGED_APPROACH_SPEED", "number", this.getManagedApproachSpeed());
+        }
+        this.updateRadioNavState();
+    }
+    onEvent(_event) {
+        if (_event.indexOf("1_BTN_") !== -1 || _event.indexOf("BTN_") !== -1) {
+            let input = _event.replace("1_BTN_", "").replace("BTN_", "");
+            if (this.onInputAircraftSpecific(input)) {
+                return;
+            }
+            if (input === "INIT") {
+                this.onInit();
+            }
+            else if (input === "DEPARR") {
+                this.onDepArr();
+            }
+            else if (input === "ATC") {
+                this.onAtc();
+            }
+            else if (input === "FIX") {
+                this.onFix();
+            }
+            else if (input === "HOLD") {
+                this.onHold();
+            }
+            else if (input === "FMCCOMM") {
+                this.onFmcComm();
+            }
+            else if (input === "PROG") {
+                this.onProg();
+            }
+            else if (input === "MENU") {
+                this.onMenu();
+            }
+            else if (input === "NAVRAD") {
+                this.onRad();
+            }
+            else if (input === "PREVPAGE") {
+                this.onPrevPage();
+            }
+            else if (input === "NEXTPAGE") {
+                this.onNextPage();
+            }
+            else if (input === "SP") {
+                this.onSp();
+            }
+            else if (input === "DEL") {
+                this.onDel();
+            }
+            else if (input === "CLR") {
+                this.onClr();
+            }
+            else if (input === "CLR_Long") {
+                this.onClrLong();
+            }
+            else if (input === "DIV") {
+                this.onDiv();
+            }
+            else if (input === "DOT") {
+                this.inOut += ".";
+            }
+            else if (input === "PLUSMINUS") {
+                this.inOut += "-";
+            }
+            else if (input === "Localizer") {
+                this._apLocalizerOn = !this._apLocalizerOn;
+            }
+            else if (input.length === 2 && input[0] === "L") {
+                let v = parseInt(input[1]);
+                if (isFinite(v)) {
+                    if (this.onLeftInput[v - 1]) {
+                        this.onLeftInput[v - 1]();
+                    }
+                }
+            }
+            else if (input.length === 2 && input[0] === "R") {
+                let v = parseInt(input[1]);
+                if (isFinite(v)) {
+                    if (this.onRightInput[v - 1]) {
+                        this.onRightInput[v - 1]();
+                    }
+                }
+            }
+            else if (input.length === 1 && FMCMainDisplay._AvailableKeys.indexOf(input) !== -1) {
+                this.onLetterInput(input);
+            }
+            else {
+                console.log("'" + input + "'");
+            }
+        }
+    }
+    clearDisplay() {
+        this.setTitle("UNTITLED");
+        this.setPageCurrent(0);
+        this.setPageCount(0);
+        for (let i = 0; i < 6; i++) {
+            this.setLabel("", i, -1);
+        }
+        for (let i = 0; i < 6; i++) {
+            this.setLine("", i, -1);
+        }
+        this.onLeftInput = [];
+        this.onRightInput = [];
+        this.onPrevPage = undefined;
+        this.onNextPage = undefined;
+        this.pageUpdate = undefined;
+        this.refreshPageCallback = undefined;
+    }
+    generateHTMLLayout(parent) {
+        while (parent.children.length > 0) {
+            parent.removeChild(parent.children[0]);
+        }
+        let header = document.createElement("div");
+        header.id = "header";
+        let title = document.createElement("span");
+        title.id = "title";
+        header.appendChild(title);
+        parent.appendChild(header);
+        let page = document.createElement("div");
+        page.id = "page-info";
+        page.classList.add("s-text");
+        let pageCurrent = document.createElement("span");
+        pageCurrent.id = "page-current";
+        let pageSlash = document.createElement("span");
+        pageSlash.id = "page-slash";
+        pageSlash.textContent = "/";
+        let pageCount = document.createElement("span");
+        pageCount.id = "page-count";
+        page.appendChild(pageCurrent);
+        page.appendChild(pageSlash);
+        page.appendChild(pageCount);
+        parent.appendChild(page);
+        for (let i = 0; i < 6; i++) {
+            let label = document.createElement("div");
+            label.classList.add("label", "s-text");
+            let labelLeft = document.createElement("span");
+            labelLeft.id = "label-" + i + "-left";
+            labelLeft.classList.add("fmc-block", "label", "label-left");
+            let labelRight = document.createElement("span");
+            labelRight.id = "label-" + i + "-right";
+            labelRight.classList.add("fmc-block", "label", "label-right");
+            let labelCenter = document.createElement("span");
+            labelCenter.id = "label-" + i + "-center";
+            labelCenter.classList.add("fmc-block", "label", "label-center");
+            label.appendChild(labelLeft);
+            label.appendChild(labelRight);
+            label.appendChild(labelCenter);
+            parent.appendChild(label);
+            let line = document.createElement("div");
+            line.classList.add("line");
+            let lineLeft = document.createElement("span");
+            lineLeft.id = "line-" + i + "-left";
+            lineLeft.classList.add("fmc-block", "line", "line-left");
+            let lineRight = document.createElement("span");
+            lineRight.id = "line-" + i + "-right";
+            lineRight.classList.add("fmc-block", "line", "line-right");
+            let lineCenter = document.createElement("span");
+            lineCenter.id = "line-" + i + "-center";
+            lineCenter.classList.add("fmc-block", "line", "line-center");
+            line.appendChild(lineLeft);
+            line.appendChild(lineRight);
+            line.appendChild(lineCenter);
+            parent.appendChild(line);
+        }
+        let footer = document.createElement("div");
+        footer.classList.add("line");
+        let inout = document.createElement("span");
+        inout.id = "in-out";
+        footer.appendChild(inout);
+        parent.appendChild(footer);
+    }
+    static secondsTohhmm(seconds) {
+        let h = Math.floor(seconds / 3600);
+        seconds -= h * 3600;
+        let m = Math.floor(seconds / 60);
+        return h.toFixed(0).padStart(2, "0") + m.toFixed(0).padStart(2, "0");
+    }
+    static hhmmToSeconds(hhmm) {
+        if (!hhmm) {
+            return NaN;
+        }
+        let h = parseInt(hhmm.substring(0, 2));
+        let m = parseInt(hhmm.substring(2, 4));
+        return h * 3600 + m * 60;
+    }
+    setAPSelectedSpeed(_speed, _aircraft) {
+        if (isFinite(_speed)) {
+            if (Simplane.getAutoPilotMachModeActive()) {
+                let mach = SimVar.GetGameVarValue("FROM KIAS TO MACH", "number", _speed);
+                Coherent.call("AP_MACH_VAR_SET", 1, mach);
+                SimVar.SetSimVarValue("K:AP_MANAGED_SPEED_IN_MACH_ON", "number", 1);
+                return;
+            }
+            Coherent.call("AP_SPD_VAR_SET", 1, _speed);
+            SimVar.SetSimVarValue("K:AP_MANAGED_SPEED_IN_MACH_OFF", "number", 1);
+        }
+    }
+    setAPManagedSpeed(_speed, _aircraft) {
+        if (isFinite(_speed)) {
+            if (Simplane.getAutoPilotMachModeActive()) {
+                let mach = SimVar.GetGameVarValue("FROM KIAS TO MACH", "number", _speed);
+                let cruiseMach = SimVar.GetGameVarValue("AIRCRAFT CRUISE MACH", "mach");
+                mach = Math.min(mach, cruiseMach);
+                Coherent.call("AP_MACH_VAR_SET", 2, mach);
+                SimVar.SetSimVarValue("K:AP_MANAGED_SPEED_IN_MACH_ON", "number", 1);
+                return;
+            }
+            Coherent.call("AP_SPD_VAR_SET", 2, _speed);
+            SimVar.SetSimVarValue("K:AP_MANAGED_SPEED_IN_MACH_OFF", "number", 1);
+        }
+    }
+    computeETA(distance, speed = NaN, currentTime = NaN) {
+        if (isNaN(speed)) {
+            speed = Simplane.getGroundSpeed();
+        }
+        if (speed < 10) {
+            return NaN;
+        }
+        if (isNaN(currentTime)) {
+            currentTime = SimVar.GetGlobalVarValue("LOCAL TIME", "seconds");
+        }
+        let eteSeconds = distance / speed * 3600;
+        let etaSeconds = currentTime + eteSeconds;
+        etaSeconds = etaSeconds % 86400;
+        return etaSeconds;
+    }
+    computeFuelLeft(distance, speed = NaN, currentFuel = NaN, currentFuelFlow = NaN) {
+        if (isNaN(speed)) {
+            speed = Simplane.getGroundSpeed();
+        }
+        if (speed < 10) {
+            return NaN;
+        }
+        if (isNaN(currentFuel)) {
+            currentFuel = SimVar.GetSimVarValue("FUEL TOTAL QUANTITY", "gallons") * SimVar.GetSimVarValue("FUEL WEIGHT PER GALLON", "kilograms") / 1000;
+        }
+        if (isNaN(currentFuelFlow)) {
+            currentFuelFlow = SimVar.GetSimVarValue("TURB ENG FUEL FLOW PPH:1", "pound per hour") + SimVar.GetSimVarValue("TURB ENG FUEL FLOW PPH:2", "pound per hour") + SimVar.GetSimVarValue("TURB ENG FUEL FLOW PPH:3", "pound per hour") + SimVar.GetSimVarValue("TURB ENG FUEL FLOW PPH:4", "pound per hour");
+            currentFuelFlow = currentFuelFlow / 1000 / 2.204623;
+        }
+        let time = distance / speed;
+        let fuel = currentFuelFlow * time;
+        return currentFuel - fuel;
+    }
+    setAPSpeedHoldMode() {
+        if (!Simplane.getAutoPilotMachModeActive()) {
+            if (!SimVar.GetSimVarValue("AUTOPILOT AIRSPEED HOLD", "Boolean")) {
+                SimVar.SetSimVarValue("K:AP_PANEL_SPEED_HOLD", "Number", 1);
+                console.log("Activating SPEED HOLD (Knots)");
+            }
+        }
+        else {
+            if (!SimVar.GetSimVarValue("AUTOPILOT MACH HOLD", "Boolean")) {
+                SimVar.SetSimVarValue("K:AP_PANEL_MACH_HOLD", "Number", 1);
+                console.log("Activating SPEED HOLD (Mach)");
+            }
+        }
+    }
+}
+FMCMainDisplay.approachTypes = [
+    "UNKNOWN",
+    "VFR",
+    "HEL",
+    "TACAN",
+    "NDB",
+    "LORAN",
+    "RNAV",
+    "VOR",
+    "GPS",
+    "SDF",
+    "LDA",
+    "LOC",
+    "MLS",
+    "ILS"
+];
+FMCMainDisplay.clrValue = " CLR ";
+FMCMainDisplay._AvailableKeys = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+//# sourceMappingURL=FMCMainDisplay.js.map

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js
@@ -1636,9 +1636,9 @@ class FMCMainDisplay extends BaseAirliners {
             if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_TAKEOFF) {
                 let enterClimbPhase = false;
                 //Schedules FLIGHT_PHASE_CLIMB when passing acceleration altitude
-                let agl = Simplane.getAltitudeAboveGround();
-                let accelAlt = SimVar.GetSimVarValue("L:AIRLINER_ACC_ALT", "feet");
-                if (agl > 3000) {
+                let alt = Simplane.getAltitude();
+                let accelAlt = SimVar.GetSimVarValue("L:AIRLINER_ACC_ALT", "number");
+                if (alt > accelAlt) {
                     this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_CLIMB;
                     enterClimbPhase = true;
                 }
@@ -2126,7 +2126,7 @@ class FMCMainDisplay extends BaseAirliners {
             if (isFinite(origin.altitudeinFP)) {
                 let altitude = Math.round(origin.altitudeinFP / 10) * 10;
                 this.thrustReductionAltitude = altitude + 1500;
-                this.accelerationAltitude = altitude + 1500;
+                this.accelerationAltitude = altitude + 3000;
                 if (origin.infos instanceof AirportInfo) {
                     this.transitionAltitude = origin.infos.transitionAltitude;
                 }

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js
@@ -1636,7 +1636,7 @@ class FMCMainDisplay extends BaseAirliners {
             if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_TAKEOFF) {
                 let enterClimbPhase = false;
                 let agl = Simplane.getAltitude();
-                let altValue = isFinite(this.thrustReductionAltitude) ? this.thrustReductionAltitude : 1500;
+                let altValue = 3000;
                 if (agl > altValue) {
                     this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_CLIMB;
                     enterClimbPhase = true;

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js
@@ -1635,9 +1635,10 @@ class FMCMainDisplay extends BaseAirliners {
             }
             if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_TAKEOFF) {
                 let enterClimbPhase = false;
-                let agl = Simplane.getAltitude();
-                let altValue = 3000;
-                if (agl > altValue) {
+                //Schedules FLIGHT_PHASE_CLIMB when passing acceleration altitude
+                let agl = Simplane.getAltitudeAboveGround();
+                let accelAlt = SimVar.GetSimVarValue("L:AIRLINER_ACC_ALT", "feet");
+                if (agl > 3000) {
                     this.currentFlightPhase = FlightPhase.FLIGHT_PHASE_CLIMB;
                     enterClimbPhase = true;
                 }

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js
@@ -105,7 +105,7 @@ class FMCMainDisplay extends BaseAirliners {
             color = "white";
         }
         this._title = content.split("[color]")[0];
-        this._titleElement.classList.remove("white", "blue", "yellow", "green", "red");
+        this._titleElement.classList.remove("white", "blue", "yellow", "green", "red", "magenta");
         this._titleElement.classList.add(color);
         this._titleElement.innerHTML = this._title;
     }
@@ -177,7 +177,7 @@ class FMCMainDisplay extends BaseAirliners {
                 color = "white";
             }
             let e = this._labelElements[row][col];
-            e.classList.remove("white", "blue", "yellow", "green", "red");
+            e.classList.remove("white", "blue", "yellow", "green", "red", "magenta");
             e.classList.add(color);
             label = label.split("[color]")[0];
         }

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FlightPlanManager.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FlightPlanManager.js
@@ -1,0 +1,1417 @@
+class FlightPlanManager {
+    constructor(_instrument) {
+        this._waypoints = [[], []];
+        this._approachWaypoints = [];
+        this._departureWaypointSize = 0;
+        this._arrivalWaypointSize = 0;
+        this._activeWaypointIndex = 0;
+        this._onFlightPlanUpdateCallbacks = [];
+        this.decelPrevIndex = -1;
+        this._lastDistanceToPreviousActiveWaypoint = 0;
+        this._isGoingTowardPreviousActiveWaypoint = false;
+        this._resetTimer = 0;
+        this._updateTimer = 0;
+        this._isRegistered = false;
+        this._isRegisteredAndLoaded = false;
+        this._currentFlightPlanIndex = 0;
+        this._activeWaypointIdentHasChanged = false;
+        this._timeLastSimVarCall = 0;
+        this._gpsActiveWaypointIndexHasChanged = false;
+        this._timeLastActiveWaypointIndexSimVarCall = 0;
+        this._isLoadedApproachTimeLastSimVarCall = 0;
+        this._isActiveApproachTimeLastSimVarCall = 0;
+        this._approachActivated = false;
+        FlightPlanManager.DEBUG_INSTANCE = this;
+        this.instrument = _instrument;
+        this.registerListener();
+    }
+    addHardCodedConstraints(wp) {
+        return;
+        let icao = wp.icao;
+        if (icao.indexOf("D0") != -1) {
+            wp.legAltitude1 = 500;
+        }
+        else if (icao.indexOf("BOANE") != -1) {
+            wp.legAltitude1 = 11000;
+            wp.speedConstraint = 250;
+        }
+        else if (icao.indexOf("NEHOS") != -1) {
+            wp.legAltitude1 = 8000;
+            wp.speedConstraint = 230;
+        }
+        else if (icao.indexOf("GRIFY") != -1) {
+            wp.legAltitude1 = 6000;
+            wp.speedConstraint = 210;
+        }
+        else if (icao.indexOf("WK1KSEAHELZR") != -1) {
+            wp.legAltitude1 = 4000;
+        }
+        else if (icao.indexOf("WK1KSEAKARFO") != -1) {
+            wp.legAltitude1 = 3200;
+        }
+        else if (icao.indexOf("WK1KSEADGLAS") != -1) {
+            wp.legAltitude1 = 1900;
+        }
+    }
+    update(_deltaTime) {
+        if (this._resetTimer > 0) {
+            this._resetTimer -= _deltaTime;
+            if (this._resetTimer <= 0) {
+                this._resetTimer = 0;
+                this._activeWaypointIdentHasChanged = false;
+                this._gpsActiveWaypointIndexHasChanged = false;
+            }
+        }
+        this._updateTimer += _deltaTime;
+        if (this._updateTimer >= 1000) {
+            this._updateTimer = 0;
+            let prevWaypoint = this.getPreviousActiveWaypoint();
+            if (prevWaypoint) {
+                let planeCoordinates = new LatLong(SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude"), SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude"));
+                if (isFinite(planeCoordinates.lat) && isFinite(planeCoordinates.long)) {
+                    let dist = Avionics.Utils.computeGreatCircleDistance(planeCoordinates, prevWaypoint.infos.coordinates);
+                    if (isFinite(dist)) {
+                        if (dist < this._lastDistanceToPreviousActiveWaypoint && dist > 2) {
+                            this._isGoingTowardPreviousActiveWaypoint = true;
+                        }
+                        else {
+                            this._isGoingTowardPreviousActiveWaypoint = false;
+                        }
+                        this._lastDistanceToPreviousActiveWaypoint = dist;
+                        if ((this._activeWaypointIdentHasChanged || this._gpsActiveWaypointIndexHasChanged) && this._resetTimer <= 0) {
+                            this._resetTimer = 3000;
+                        }
+                        return;
+                    }
+                }
+            }
+            if ((this._activeWaypointIdentHasChanged || this._gpsActiveWaypointIndexHasChanged) && this._resetTimer <= 0) {
+                this._resetTimer = 3000;
+            }
+            this._isGoingTowardPreviousActiveWaypoint = false;
+        }
+    }
+    onCurrentGameFlightLoaded(_callback) {
+        if (this._isRegisteredAndLoaded) {
+            _callback();
+            return;
+        }
+        this._onCurrentGameFlightLoaded = _callback;
+    }
+    registerListener() {
+        if (this._isRegistered) {
+            return;
+        }
+        this._isRegistered = true;
+        RegisterViewListener("JS_LISTENER_FLIGHTPLAN");
+        setTimeout(() => {
+            Coherent.call("LOAD_CURRENT_GAME_FLIGHT");
+            Coherent.call("LOAD_CURRENT_ATC_FLIGHTPLAN");
+            setTimeout(() => {
+                this._isRegisteredAndLoaded = true;
+                if (this._onCurrentGameFlightLoaded) {
+                    this._onCurrentGameFlightLoaded();
+                }
+            }, 200);
+        }, 200);
+    }
+    hasFlightPlan() {
+        if (this.getWaypointsCount() > 0)
+            return true;
+        return false;
+    }
+    _loadWaypoints(data, currentWaypoints, callback) {
+        let waypoints = [];
+        let todo = data.length;
+        let done = 0;
+        let activeWaypointIndex = this.getActiveWaypointIndex(false, true);
+        let isApproachActive = this.isActiveApproach(false);
+        let timenow = SimVar.GetGlobalVarValue("ZULU TIME", "seconds");
+        for (let i = 0; i < data.length; i++) {
+            let waypointData = data[i];
+            let ii = i;
+            let icao = waypointData.icao;
+            if (waypointData.icao[0] === " " || waypointData.icao[0] == "U" || waypointData.icao[0] == "R") {
+                if (waypointData.icao[0] === " ") {
+                    icao = icao.replace(" ", "U");
+                }
+                icao += "_" + ii;
+                if (this.getApproachTransitionIndex() >= 0) {
+                    icao += this.getApproachTransitionIndex().toFixed(0);
+                }
+                if (this.getApproachIndex() >= 0) {
+                    icao += this.getApproachIndex().toFixed(0);
+                }
+            }
+            if (currentWaypoints[ii] &&
+                currentWaypoints[ii].infos &&
+                currentWaypoints[ii].infos.icao === icao) {
+                let v = currentWaypoints[ii];
+                waypoints[ii] = v;
+                v.bearingInFP = isFinite(waypointData.heading) ? waypointData.heading : 0;
+                v.distanceInFP = waypointData.distance;
+                v.altitudeinFP = waypointData.lla.alt * 3.2808;
+                v.altitudeModeinFP = waypointData.altitudeMode;
+                if (i != data.length - 1 || !this._approachWaypoints) {
+                    v.estimatedTimeOfArrivalFP = waypointData.estimatedTimeOfArrival;
+                    if (!isApproachActive) {
+                        if (this.getIsDirectTo() && this.getDirectToTarget().icao === v.icao) {
+                            let d = this.getDistanceToDirectToTarget();
+                            let gs = Simplane.getGroundSpeed();
+                            if (gs < 100) {
+                                gs = 100;
+                            }
+                            v.estimatedTimeOfArrivalFP = timenow + d / gs * 3600;
+                            v.estimatedTimeOfArrivalFP = v.estimatedTimeOfArrivalFP % 86400;
+                        }
+                        else if (ii < activeWaypointIndex) {
+                            v.estimatedTimeOfArrivalFP = timenow;
+                        }
+                        else if (ii === activeWaypointIndex) {
+                            let d = this.getDistanceToActiveWaypoint();
+                            let gs = Simplane.getGroundSpeed();
+                            if (gs < 100) {
+                                gs = 100;
+                            }
+                            v.estimatedTimeOfArrivalFP = timenow + d / gs * 3600;
+                            v.estimatedTimeOfArrivalFP = v.estimatedTimeOfArrivalFP % 86400;
+                        }
+                        else {
+                            let vPrev = currentWaypoints[ii - 1];
+                            if (vPrev) {
+                                v.estimatedTimeOfArrivalFP = vPrev.estimatedTimeOfArrivalFP + v.estimatedTimeEnRouteFP;
+                                v.estimatedTimeOfArrivalFP = v.estimatedTimeOfArrivalFP % 86400;
+                            }
+                        }
+                    }
+                    v.estimatedTimeEnRouteFP = waypointData.estimatedTimeEnRoute;
+                    v.cumulativeEstimatedTimeEnRouteFP = waypointData.cumulativeEstimatedTimeEnRoute;
+                    v.cumulativeDistanceInFP = waypointData.cumulativeDistance;
+                }
+                v.infos.totalDistInFP = waypointData.cumulativeDistance;
+                v.infos.totalTimeInFP = waypointData.estimatedTimeEnRoute;
+                v.infos.airwayIdentInFP = waypointData.airwayIdent;
+                v.speedConstraint = waypointData.speedConstraint;
+                v.transitionLLas = waypointData.transitionLLas;
+                if (v.speedConstraint > 0) {
+                }
+                if (v.speedConstraint > 400) {
+                    v.speedConstraint = -1;
+                }
+                if ((ii > 0 && ii <= this.getDepartureWaypointsCount()) && (v.altitudeinFP >= 1000)) {
+                    v.legAltitudeDescription = 2;
+                    v.legAltitude1 = v.altitudeinFP;
+                }
+                else if ((ii < (data.length - 1) && ii >= (data.length - 1 - this.getArrivalWaypointsCount())) && (v.altitudeinFP >= 1000)) {
+                    v.legAltitudeDescription = 2;
+                    v.legAltitude1 = v.altitudeinFP;
+                }
+                else if (ii > 0 && ii < data.length - 1 && (v.altitudeinFP >= 1000)) {
+                    v.legAltitudeDescription = 1;
+                    v.legAltitude1 = v.altitudeinFP;
+                }
+                else if (currentWaypoints === this._approachWaypoints) {
+                    v.legAltitudeDescription = 1;
+                    v.legAltitude1 = v.altitudeinFP;
+                }
+                this.addHardCodedConstraints(v);
+                done++;
+            }
+            else {
+                if (waypointData.icao[0] === " " || waypointData.icao[0] == "U" || waypointData.icao[0] == "R" || waypointData.ident === "CUSTD" || waypointData.ident === "CUSTA") {
+                    let wp = new WayPoint(this.instrument);
+                    wp.infos = new IntersectionInfo(this.instrument);
+                    wp.icao = icao;
+                    wp.infos.icao = wp.icao;
+                    wp.ident = waypointData.ident;
+                    wp.infos.ident = waypointData.ident;
+                    wp.infos.coordinates = new LatLongAlt(waypointData.lla);
+                    wp.latitudeFP = waypointData.lla.lat;
+                    wp.longitudeFP = waypointData.lla.long;
+                    wp.altitudeinFP = waypointData.lla.alt * 3.2808;
+                    wp.altitudeModeinFP = waypointData.altitudeMode;
+                    wp.bearingInFP = isFinite(waypointData.heading) ? waypointData.heading : 0;
+                    wp.distanceInFP = waypointData.distance;
+                    wp.cumulativeDistanceInFP = waypointData.cumulativeDistance;
+                    wp.infos.totalDistInFP = waypointData.cumulativeDistance;
+                    wp.estimatedTimeOfArrivalFP = waypointData.estimatedTimeOfArrival;
+                    wp.estimatedTimeEnRouteFP = waypointData.estimatedTimeEnRoute;
+                    wp.cumulativeEstimatedTimeEnRouteFP = waypointData.cumulativeEstimatedTimeEnRoute;
+                    wp.infos.totalTimeInFP = waypointData.estimatedTimeEnRoute;
+                    wp.infos.airwayIdentInFP = waypointData.airwayIdent;
+                    wp.speedConstraint = waypointData.speedConstraint;
+                    wp.transitionLLas = waypointData.transitionLLas;
+                    if (wp.speedConstraint > 0) {
+                    }
+                    if (wp.speedConstraint > 400) {
+                        wp.speedConstraint = -1;
+                    }
+                    if ((ii > 0 && ii <= this.getDepartureWaypointsCount()) && (wp.altitudeinFP >= 1000)) {
+                        wp.legAltitudeDescription = 2;
+                        wp.legAltitude1 = wp.altitudeinFP;
+                    }
+                    else if ((ii < (data.length - 1) && ii >= (data.length - 1 - this.getArrivalWaypointsCount())) && (wp.altitudeinFP >= 1000)) {
+                        wp.legAltitudeDescription = 2;
+                        wp.legAltitude1 = wp.altitudeinFP;
+                    }
+                    else if (ii > 0 && ii < data.length - 1 && (wp.altitudeinFP >= 1000)) {
+                        wp.legAltitudeDescription = 1;
+                        wp.legAltitude1 = wp.altitudeinFP;
+                    }
+                    this.addHardCodedConstraints(wp);
+                    waypoints[ii] = wp;
+                    done++;
+                }
+                else {
+                    this.instrument.facilityLoader.getFacility(waypointData.icao).then((v) => {
+                        done++;
+                        waypoints[ii] = v;
+                        if (v) {
+                            v.infos.icao = v.icao;
+                            v.infos.ident = v.ident;
+                            v.latitudeFP = waypointData.lla.lat;
+                            v.longitudeFP = waypointData.lla.long;
+                            v.altitudeinFP = waypointData.lla.alt * 3.2808;
+                            v.altitudeModeinFP = waypointData.altitudeMode;
+                            v.bearingInFP = isFinite(waypointData.heading) ? waypointData.heading : 0;
+                            v.distanceInFP = waypointData.distance;
+                            v.cumulativeDistanceInFP = waypointData.cumulativeDistance;
+                            v.infos.totalDistInFP = waypointData.cumulativeDistance;
+                            v.estimatedTimeOfArrivalFP = waypointData.estimatedTimeOfArrival;
+                            v.estimatedTimeEnRouteFP = waypointData.estimatedTimeEnRoute;
+                            v.cumulativeEstimatedTimeEnRouteFP = waypointData.cumulativeEstimatedTimeEnRoute;
+                            v.infos.totalTimeInFP = waypointData.estimatedTimeEnRoute;
+                            v.infos.airwayIdentInFP = waypointData.airwayIdent;
+                            v.speedConstraint = waypointData.speedConstraint;
+                            v.transitionLLas = waypointData.transitionLLas;
+                            if (v.speedConstraint > 0) {
+                            }
+                            if (v.speedConstraint > 400) {
+                                v.speedConstraint = -1;
+                            }
+                            if ((ii > 0 && ii <= this.getDepartureWaypointsCount()) && (v.altitudeinFP >= 1000)) {
+                                v.legAltitudeDescription = 2;
+                                v.legAltitude1 = v.altitudeinFP;
+                            }
+                            else if ((ii < (data.length - 1) && ii >= (data.length - 1 - this.getArrivalWaypointsCount())) && (v.altitudeinFP >= 1000)) {
+                                v.legAltitudeDescription = 2;
+                                v.legAltitude1 = v.altitudeinFP;
+                            }
+                            else if (ii > 0 && ii < data.length - 1 && (v.altitudeinFP >= 1000)) {
+                                v.legAltitudeDescription = 1;
+                                v.legAltitude1 = v.altitudeinFP;
+                            }
+                            this.addHardCodedConstraints(v);
+                        }
+                    });
+                }
+            }
+        }
+        let destination = this.getDestination();
+        if (destination) {
+            if (SimVar.GetSimVarValue("L:FLIGHTPLAN_USE_DECEL_WAYPOINT", "number") === 1) {
+                setTimeout(() => {
+                    if (!this.decelWaypoint) {
+                        this.decelWaypoint = new WayPoint(this.instrument);
+                        this.decelWaypoint.infos = new IntersectionInfo(this.instrument);
+                    }
+                    this.decelWaypoint.icao = "";
+                    this.decelWaypoint.infos.icao = this.decelWaypoint.icao;
+                    this.decelWaypoint.ident = "DECEL";
+                    this.decelWaypoint.infos.ident = this.decelWaypoint.ident;
+                    let r = this.getCoordinatesAtNMFromDestinationAlongFlightPlan(32);
+                    if (r) {
+                        let decelCoordinates = r.lla;
+                        this.decelWaypoint.infos.coordinates = new LatLongAlt(decelCoordinates.lat, decelCoordinates.long);
+                        this.decelWaypoint.latitudeFP = this.decelWaypoint.infos.coordinates.lat;
+                        this.decelWaypoint.longitudeFP = this.decelWaypoint.infos.coordinates.long;
+                        this.decelWaypoint.altitudeinFP = this.decelWaypoint.infos.coordinates.alt;
+                        let destination = this.getDestination();
+                        if (destination) {
+                            this.decelWaypoint.cumulativeDistanceInFP = destination.cumulativeDistanceInFP - 32;
+                        }
+                        this.decelPrevIndex = r.prevIndex;
+                        let prevWaypoint = this.getWaypoint(r.prevIndex, undefined, true);
+                        if (prevWaypoint) {
+                            this.decelWaypoint.legAltitude1 = prevWaypoint.legAltitude1;
+                            this.decelWaypoint.legAltitudeDescription = prevWaypoint.legAltitudeDescription;
+                            this.decelWaypoint.estimatedTimeOfArrivalFP = prevWaypoint.estimatedTimeOfArrivalFP;
+                        }
+                    }
+                }, 300);
+            }
+        }
+        let delayCallback = () => {
+            if (done === todo) {
+                if (callback) {
+                    callback(waypoints);
+                }
+            }
+            else {
+                this.instrument.requestCall(delayCallback);
+            }
+        };
+        delayCallback();
+    }
+    updateWaypointIndex() {
+        Coherent.call("GET_ACTIVE_WAYPOINT_INDEX").then((waypointIndex) => {
+            this._activeWaypointIndex = waypointIndex;
+        });
+    }
+    updateFlightPlan(callback = () => { }, log = false) {
+        let t0 = performance.now();
+        Coherent.call("GET_FLIGHTPLAN").then((flightPlanData) => {
+            let t1 = performance.now();
+            if (log) {
+            }
+            let index = flightPlanData.flightPlanIndex;
+            this._cruisingAltitude = flightPlanData.cruisingAltitude;
+            this._activeWaypointIndex = flightPlanData.activeWaypointIndex;
+            this._departureWaypointSize = Math.max(0, flightPlanData.departureWaypointsSize);
+            this._runwayIndex = flightPlanData.originRunwayIndex;
+            this._departureRunwayIndex = flightPlanData.departureRunwayIndex;
+            this._departureProcIndex = flightPlanData.departureProcIndex;
+            this._departureEnRouteTransitionIndex = flightPlanData.departureEnRouteTransitionIndex;
+            this._departureDiscontinuity = flightPlanData.departureDiscontinuity;
+            this._arrivalWaypointSize = Math.max(0, flightPlanData.arrivalWaypointsSize);
+            this._arrivalProcIndex = flightPlanData.arrivalProcIndex;
+            this._arrivalTransitionIndex = flightPlanData.arrivalEnRouteTransitionIndex;
+            this._arrivalDiscontinuity = flightPlanData.arrivalDiscontinuity;
+            this._approachIndex = flightPlanData.approachIndex;
+            this._approachTransitionIndex = flightPlanData.approachTransitionIndex;
+            this._lastIndexBeforeApproach = flightPlanData.lastIndexBeforeApproach;
+            this._isDirectTo = flightPlanData.isDirectTo;
+            if (!this._directToTarget) {
+                this._directToTarget = new WayPoint(this.instrument);
+                this._directToTarget.infos = new IntersectionInfo(this.instrument);
+            }
+            this._directToTarget.icao = flightPlanData.directToTarget.icao;
+            this._directToTarget.infos.icao = this._directToTarget.icao;
+            this._directToTarget.ident = flightPlanData.directToTarget.ident;
+            if (!this._directToTarget.ident) {
+                this._directToTarget.ident = this._directToTarget.icao.substr(7);
+            }
+            this._directToTarget.infos.ident = this._directToTarget.ident;
+            this._directToTarget.infos.coordinates = new LatLongAlt(flightPlanData.directToTarget.lla);
+            this._directToOrigin = new LatLongAlt(flightPlanData.directToOrigin);
+            if (!this._waypoints[index]) {
+                this._waypoints[index] = [];
+            }
+            this._loadWaypoints(flightPlanData.waypoints, this._waypoints[index], (wps) => {
+                this._waypoints[index] = wps;
+                let t2 = performance.now();
+                if (log) {
+                }
+                if (callback) {
+                    callback();
+                }
+            });
+        });
+    }
+    updateCurrentApproach(callback = () => { }, log = false) {
+        let t0 = performance.now();
+        Coherent.call("GET_APPROACH_FLIGHTPLAN").then((flightPlanData) => {
+            this._loadWaypoints(flightPlanData.waypoints, this._approachWaypoints, (wps) => {
+                this._approachWaypoints = wps;
+                let previousWaypoint = this.getWaypoint(this.getWaypointsCount() - 2);
+                let activeWaypoint = this.getActiveWaypoint(false, true);
+                for (let i = 0; i < this._approachWaypoints.length; i++) {
+                    let waypoint = this._approachWaypoints[i];
+                    if (waypoint) {
+                        if (previousWaypoint && waypoint.infos) {
+                            waypoint.distanceInFP = Avionics.Utils.computeGreatCircleDistance(previousWaypoint.infos.coordinates, waypoint.infos.coordinates);
+                            waypoint.estimatedTimeEnRouteFP = waypoint.distanceInFP / 200 * 3600;
+                            waypoint.cumulativeEstimatedTimeEnRouteFP = waypoint.estimatedTimeEnRouteFP + previousWaypoint.cumulativeEstimatedTimeEnRouteFP;
+                            if (this.getIsDirectTo() && this.getDirectToTarget().icao === waypoint.icao) {
+                                let d = this.getDistanceToDirectToTarget();
+                                let gs = Simplane.getGroundSpeed();
+                                if (gs < 100) {
+                                    gs = 100;
+                                }
+                                let timenow = SimVar.GetGlobalVarValue("ZULU TIME", "seconds");
+                                waypoint.estimatedTimeOfArrivalFP = timenow + d / gs * 3600;
+                                waypoint.estimatedTimeOfArrivalFP = waypoint.estimatedTimeOfArrivalFP % 86400;
+                            }
+                            else if (activeWaypoint && activeWaypoint.icao === waypoint.icao) {
+                                let d = this.getDistanceToActiveWaypoint();
+                                let gs = Simplane.getGroundSpeed();
+                                if (gs < 100) {
+                                    gs = 100;
+                                }
+                                let timenow = SimVar.GetGlobalVarValue("ZULU TIME", "seconds");
+                                waypoint.estimatedTimeOfArrivalFP = timenow + d / gs * 3600;
+                                waypoint.estimatedTimeOfArrivalFP = waypoint.estimatedTimeOfArrivalFP % 86400;
+                            }
+                            else {
+                                waypoint.estimatedTimeOfArrivalFP = waypoint.estimatedTimeEnRouteFP + previousWaypoint.estimatedTimeOfArrivalFP;
+                            }
+                            waypoint.cumulativeDistanceInFP = previousWaypoint.cumulativeDistanceInFP + waypoint.distanceInFP;
+                            if (i === this._approachWaypoints.length - 1) {
+                                let destination = this.getDestination();
+                                if (destination) {
+                                    destination.estimatedTimeOfArrivalFP = waypoint.estimatedTimeOfArrivalFP;
+                                    destination.estimatedTimeEnRouteFP = waypoint.estimatedTimeEnRouteFP;
+                                    destination.cumulativeEstimatedTimeEnRouteFP = waypoint.cumulativeEstimatedTimeEnRouteFP;
+                                    destination.cumulativeDistanceInFP = waypoint.cumulativeDistanceInFP;
+                                }
+                            }
+                            waypoint.bearingInFP = Avionics.Utils.computeGreatCircleHeading(previousWaypoint.infos.coordinates, waypoint.infos.coordinates);
+                        }
+                        this.addHardCodedConstraints(waypoint);
+                        previousWaypoint = waypoint;
+                    }
+                }
+            });
+        });
+        Coherent.call("GET_CURRENT_APPROACH").then((approachData) => {
+            let t1 = performance.now();
+            if (log) {
+                console.log("Approach Data loaded from FlightPlanManager in " + (t1 - t0).toFixed(2) + " ms.");
+                console.log(approachData);
+            }
+            if (!this._approach) {
+                this._approach = new Approach();
+            }
+            this._approach.name = approachData.name;
+            this._approach.runway = approachData.name.split(" ")[1];
+            this._approach.transitions = [];
+            for (let i = 0; i < approachData.transitions.length; i++) {
+                let transitionData = approachData.transitions[i];
+                let transition = new Transition();
+                transition.name = transitionData.name;
+                let previousWaypoint = this.getWaypoint(this.getWaypointsCount() - 2);
+                for (let j = 1; j < transitionData.waypoints.length; j++) {
+                    let waypointData = transitionData.waypoints[j];
+                    let waypoint = new WayPoint(this.instrument);
+                    waypoint.infos = new IntersectionInfo(this.instrument);
+                    waypoint.icao = waypointData.icao;
+                    waypoint.infos.icao = waypoint.icao;
+                    waypoint.ident = waypointData.ident;
+                    if (!waypoint.ident) {
+                        waypoint.ident = waypoint.icao.substr(7);
+                    }
+                    waypoint.infos.ident = waypoint.ident;
+                    waypoint.infos.coordinates = new LatLongAlt(waypointData.lla);
+                    waypoint.latitudeFP = waypointData.lla.lat;
+                    waypoint.longitudeFP = waypointData.lla.lon;
+                    waypoint.altitudeinFP = waypointData.lla.alt * 3.2808;
+                    waypoint.altitudeModeinFP = waypointData.altitudeMode;
+                    waypoint.transitionLLas = waypointData.transitionLLas;
+                    let altitudeConstraintInFeet = waypoint.altitudeinFP;
+                    if (altitudeConstraintInFeet >= 1000) {
+                        waypoint.legAltitudeDescription = 1;
+                        waypoint.legAltitude1 = altitudeConstraintInFeet;
+                    }
+                    waypoint.speedConstraint = waypointData.speedConstraint;
+                    if (waypoint.speedConstraint > 0) {
+                    }
+                    if (waypoint.speedConstraint > 400) {
+                        waypoint.speedConstraint = -1;
+                    }
+                    if (previousWaypoint) {
+                        waypoint.distanceInFP = Avionics.Utils.computeGreatCircleDistance(previousWaypoint.infos.coordinates, waypoint.infos.coordinates);
+                        waypoint.cumulativeDistanceInFP = previousWaypoint.cumulativeDistanceInFP + waypoint.distanceInFP;
+                        waypoint.bearingInFP = Avionics.Utils.computeGreatCircleHeading(previousWaypoint.infos.coordinates, waypoint.infos.coordinates);
+                    }
+                    transition.waypoints.push(waypoint);
+                    previousWaypoint = waypoint;
+                }
+                transition.waypoints.push(this._waypoints[this._currentFlightPlanIndex][this._waypoints[this._currentFlightPlanIndex].length - 1]);
+                this._approach.transitions.push(transition);
+            }
+            if (log) {
+                console.log("FlightPlanManager now");
+                console.log(this);
+            }
+            callback();
+        });
+    }
+    get cruisingAltitude() {
+        return this._cruisingAltitude;
+    }
+    getCurrentFlightPlanIndex() {
+        return this._currentFlightPlanIndex;
+    }
+    setCurrentFlightPlanIndex(index, callback = EmptyCallback.Boolean) {
+        Coherent.call("SET_CURRENT_FLIGHTPLAN_INDEX", index).then(() => {
+            let attempts = 0;
+            let checkTrueFlightPlanIndex = () => {
+                Coherent.call("GET_CURRENT_FLIGHTPLAN_INDEX").then((value) => {
+                    attempts++;
+                    if (value === index) {
+                        console.log("setCurrentFlightPlanIndex : Values matching, return after " + attempts + " attempts");
+                        this._currentFlightPlanIndex = index;
+                        this.updateFlightPlan(() => {
+                            callback(true);
+                        });
+                        return;
+                    }
+                    else {
+                        if (attempts < 60) {
+                            console.log("setCurrentFlightPlanIndex : Values mistmatch, retrying");
+                            this.instrument.requestCall(checkTrueFlightPlanIndex);
+                            return;
+                        }
+                        else {
+                            console.log("setCurrentFlightPlanIndex : Values mistmatched too long, aborting");
+                            return callback(false);
+                        }
+                    }
+                });
+            };
+            checkTrueFlightPlanIndex();
+        });
+    }
+    createNewFlightPlan(callback = EmptyCallback.Void) {
+        Coherent.call("CREATE_NEW_FLIGHTPLAN").then(() => {
+            this.instrument.requestCall(callback);
+        });
+    }
+    copyCurrentFlightPlanInto(index, callback = EmptyCallback.Void) {
+        Coherent.call("COPY_CURRENT_FLIGHTPLAN_TO", index).then(() => {
+            this.instrument.requestCall(callback);
+        });
+    }
+    copyFlightPlanIntoCurrent(index, callback = EmptyCallback.Void) {
+        Coherent.call("COPY_FLIGHTPLAN_TO_CURRENT", index).then(() => {
+            this.instrument.requestCall(callback);
+        });
+    }
+    clearFlightPlan(callback = EmptyCallback.Void) {
+        Coherent.call("CLEAR_CURRENT_FLIGHT_PLAN").then(() => {
+            this.updateFlightPlan(() => {
+                this.updateCurrentApproach(() => {
+                    this.instrument.requestCall(callback);
+                });
+            });
+        });
+    }
+    getOrigin() {
+        if (this._waypoints.length > 0) {
+            return this._waypoints[this._currentFlightPlanIndex][0];
+        }
+        else {
+            return null;
+        }
+    }
+    setOrigin(icao, callback = () => { }) {
+        Coherent.call("SET_ORIGIN", icao).then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    getActiveWaypointIndex(forceSimVarCall = false, useCorrection = false) {
+        if (useCorrection && this._isGoingTowardPreviousActiveWaypoint) {
+            return this.getActiveWaypointIndex(forceSimVarCall, false) - 1;
+        }
+        let ident = this.getActiveWaypointIdent(forceSimVarCall);
+        if (this.isActiveApproach()) {
+            let waypointIndex = this.getApproachWaypoints().findIndex(w => { return w && w.ident === ident; });
+            return waypointIndex;
+        }
+        let waypointIndex = this.getWaypoints().findIndex(w => { return w && w.ident === ident; });
+        if (waypointIndex === -1) {
+            waypointIndex = this.getApproachWaypoints().findIndex(w => { return w && w.ident === ident; });
+        }
+        if (useCorrection && (this._activeWaypointIdentHasChanged || this._gpsActiveWaypointIndexHasChanged)) {
+            return waypointIndex - 1;
+        }
+        return waypointIndex;
+    }
+    setActiveWaypointIndex(index, callback = EmptyCallback.Void) {
+        Coherent.call("SET_ACTIVE_WAYPOINT_INDEX", index).then(callback);
+    }
+    recomputeActiveWaypointIndex(callback = EmptyCallback.Void) {
+        Coherent.call("RECOMPUTE_ACTIVE_WAYPOINT_INDEX").then(callback);
+    }
+    getPreviousActiveWaypoint(forceSimVarCall = false) {
+        let ident = this.getActiveWaypointIdent(forceSimVarCall);
+        if (this.isActiveApproach()) {
+            let waypointIndex = this.getApproachWaypoints().findIndex(w => { return (w && w.ident === ident); });
+            return this.getApproachWaypoints()[waypointIndex - 1];
+        }
+        let waypointIndex = this.getWaypoints().findIndex(w => { return (w && w.ident === ident); });
+        if (waypointIndex === -1) {
+            waypointIndex = this.getApproachWaypoints().findIndex(w => { return (w && w.ident === ident); });
+        }
+        return this.getWaypoints()[waypointIndex - 1];
+    }
+    getActiveWaypointIdent(forceSimVarCall = false) {
+        let doSimVarCall = false;
+        let t = 0;
+        if (forceSimVarCall || this._activeWaypointIdent === undefined) {
+            doSimVarCall = true;
+        }
+        else {
+            t = performance.now();
+            if (t - this._timeLastSimVarCall > 1000) {
+                doSimVarCall = true;
+            }
+        }
+        if (doSimVarCall) {
+            let activeWaypointIdent = SimVar.GetSimVarValue("GPS WP NEXT ID", "string");
+            if (this._activeWaypointIdent != activeWaypointIdent) {
+                this._activeWaypointIdentHasChanged = true;
+                this._activeWaypointIdent = activeWaypointIdent;
+            }
+            this._timeLastSimVarCall = t;
+        }
+        return this._activeWaypointIdent;
+    }
+    getGPSActiveWaypointIndex(forceSimVarCall = false) {
+        let doSimVarCall = false;
+        let t = 0;
+        if (forceSimVarCall || this._gpsActiveWaypointIndex === undefined) {
+            doSimVarCall = true;
+        }
+        else {
+            t = performance.now();
+            if (t - this._timeLastActiveWaypointIndexSimVarCall > 1000) {
+                doSimVarCall = true;
+            }
+        }
+        if (doSimVarCall) {
+            let gpsActiveWaypointIndex = SimVar.GetSimVarValue("C:fs9gps:FlightPlanActiveWaypoint", "number");
+            if (this._gpsActiveWaypointIndex != gpsActiveWaypointIndex) {
+                this._gpsActiveWaypointIndexHasChanged = true;
+                this._gpsActiveWaypointIndex = gpsActiveWaypointIndex;
+            }
+            this._timeLastActiveWaypointIndexSimVarCall = t;
+        }
+        return this._gpsActiveWaypointIndex;
+    }
+    getActiveWaypoint(forceSimVarCall = false, useCorrection = false) {
+        if (this.getIsDirectTo()) {
+            return this.getDirectToTarget();
+        }
+        if (useCorrection && this._isGoingTowardPreviousActiveWaypoint) {
+            return this.getPreviousActiveWaypoint(forceSimVarCall);
+        }
+        if (!this.isActiveApproach()) {
+            let index = this.getActiveWaypointIndex(forceSimVarCall);
+            let waypoint = this.getWaypoints()[index];
+            if (waypoint) {
+                if (useCorrection && (this._activeWaypointIdentHasChanged || this._gpsActiveWaypointIndexHasChanged)) {
+                    return this.getPreviousActiveWaypoint(forceSimVarCall);
+                }
+                return waypoint;
+            }
+        }
+        let ident = this.getActiveWaypointIdent(forceSimVarCall);
+        if (this.isActiveApproach()) {
+            let waypoint = this.getApproachWaypoints().find(w => { return (w && w.ident === ident); });
+            return waypoint;
+        }
+        let waypoint = this.getWaypoints().find(w => { return (w && w.ident === ident); });
+        if (!waypoint) {
+            waypoint = this.getApproachWaypoints().find(w => { return (w && w.ident === ident); });
+        }
+        if (!waypoint && this._directToTarget && ident != "" && ident === this._directToTarget.ident) {
+            waypoint = this._directToTarget;
+        }
+        if (useCorrection && (this._activeWaypointIdentHasChanged || this._gpsActiveWaypointIndexHasChanged)) {
+            return this.getPreviousActiveWaypoint(forceSimVarCall);
+        }
+        return waypoint;
+    }
+    getNextActiveWaypoint(forceSimVarCall = false) {
+        let ident = this.getActiveWaypointIdent(forceSimVarCall);
+        if (this.isActiveApproach()) {
+            let waypointIndex = this.getApproachWaypoints().findIndex(w => { return (w && w.ident === ident); });
+            return this.getApproachWaypoints()[waypointIndex + 1];
+        }
+        let waypointIndex = this.getWaypoints().findIndex(w => { return (w && w.ident === ident); });
+        if (waypointIndex === -1) {
+            waypointIndex = this.getApproachWaypoints().findIndex(w => { return (w && w.ident === ident); });
+        }
+        return this.getWaypoints()[waypointIndex + 1];
+    }
+    getDistanceToActiveWaypoint() {
+        let lat = SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude");
+        let long = SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude");
+        let ll = new LatLong(lat, long);
+        let waypoint = this.getActiveWaypoint();
+        if (waypoint && waypoint.infos) {
+            return Avionics.Utils.computeDistance(ll, waypoint.infos.coordinates);
+        }
+        return 0;
+    }
+    getDistanceToDirectToTarget() {
+        let lat = SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude");
+        let long = SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude");
+        let ll = new LatLong(lat, long);
+        let waypoint = this.getDirectToTarget();
+        if (waypoint && waypoint.infos) {
+            return Avionics.Utils.computeDistance(ll, waypoint.infos.coordinates);
+        }
+        return 0;
+    }
+    getBearingToActiveWaypoint() {
+        let lat = SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude");
+        let long = SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude");
+        let ll = new LatLong(lat, long);
+        let waypoint = this.getActiveWaypoint();
+        if (waypoint && waypoint.infos) {
+            return Avionics.Utils.computeGreatCircleHeading(ll, waypoint.infos.coordinates);
+        }
+        return 0;
+    }
+    getETEToActiveWaypoint() {
+        let lat = SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude");
+        let long = SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude");
+        let ll = new LatLong(lat, long);
+        let waypoint = this.getActiveWaypoint();
+        if (waypoint && waypoint.infos) {
+            let dist = Avionics.Utils.computeDistance(ll, waypoint.infos.coordinates);
+            let groundSpeed = SimVar.GetSimVarValue("GPS GROUND SPEED", "knots");
+            if (groundSpeed < 50) {
+                groundSpeed = 50;
+            }
+            if (groundSpeed > 0.1) {
+                return dist / groundSpeed * 3600;
+            }
+        }
+        return 0;
+    }
+    getDestination() {
+        if (this._waypoints[this._currentFlightPlanIndex].length > 1) {
+            if (this._waypoints[this._currentFlightPlanIndex].length === 2 && this.getWaypoint(0).icao === this.getWaypoint(1).icao) {
+                return undefined;
+            }
+            return this._waypoints[this._currentFlightPlanIndex][this._waypoints[this._currentFlightPlanIndex].length - 1];
+        }
+        else {
+            return undefined;
+        }
+    }
+    getDeparture() {
+        let origin = this.getOrigin();
+        if (origin) {
+            let originInfos = origin.infos;
+            if (originInfos instanceof AirportInfo) {
+                return originInfos.departures[this._departureProcIndex];
+            }
+        }
+    }
+    getArrival() {
+        let destination = this.getDestination();
+        if (destination) {
+            let destinationInfos = destination.infos;
+            if (destinationInfos instanceof AirportInfo) {
+                return destinationInfos.arrivals[this._arrivalProcIndex];
+            }
+        }
+    }
+    getAirportApproach() {
+        let destination = this.getDestination();
+        if (destination) {
+            let destinationInfos = destination.infos;
+            if (destinationInfos instanceof AirportInfo) {
+                return destinationInfos.approaches[this._approachIndex];
+            }
+        }
+    }
+    getDepartureWaypoints() {
+        let departureWaypoints = [];
+        let origin = this.getOrigin();
+        if (origin) {
+            let originInfos = origin.infos;
+            if (originInfos instanceof AirportInfo) {
+                let departure = originInfos.departures[this._departureProcIndex];
+                if (departure) {
+                    let runwayTransition = departure.runwayTransitions[0];
+                    if (departure.runwayTransitions.length > 0) {
+                        runwayTransition = departure.runwayTransitions[this._departureRunwayIndex];
+                    }
+                    if (runwayTransition && runwayTransition.legs) {
+                        for (let i = 0; i < runwayTransition.legs.length; i++) {
+                            let wp = new WayPoint(this.instrument);
+                            wp.icao = runwayTransition.legs[i].fixIcao;
+                            wp.ident = wp.icao.substr(7);
+                            departureWaypoints.push(wp);
+                        }
+                    }
+                    if (departure && departure.commonLegs) {
+                        for (let i = 0; i < departure.commonLegs.length; i++) {
+                            let wp = new WayPoint(this.instrument);
+                            wp.icao = departure.commonLegs[i].fixIcao;
+                            wp.ident = wp.icao.substr(7);
+                            departureWaypoints.push(wp);
+                        }
+                    }
+                    let enRouteTransition = departure.enRouteTransitions[0];
+                    if (departure.enRouteTransitions.length > 0) {
+                        enRouteTransition = departure.enRouteTransitions[this._departureRunwayIndex];
+                    }
+                    if (enRouteTransition && enRouteTransition.legs) {
+                        for (let i = 0; i < enRouteTransition.legs.length; i++) {
+                            let wp = new WayPoint(this.instrument);
+                            wp.icao = enRouteTransition.legs[i].fixIcao;
+                            wp.ident = wp.icao.substr(7);
+                            departureWaypoints.push(wp);
+                        }
+                    }
+                }
+            }
+        }
+        return departureWaypoints;
+    }
+    getDepartureWaypointsMap() {
+        let departureWaypoints = [];
+        for (let i = 1; i < this._departureWaypointSize + 1; i++) {
+            departureWaypoints.push(this._waypoints[this._currentFlightPlanIndex][i]);
+        }
+        return departureWaypoints;
+    }
+    getEnRouteWaypoints(outFPIndex) {
+        let enRouteWaypoints = [];
+        for (let i = (1 + this._departureWaypointSize); i < this._waypoints[this._currentFlightPlanIndex].length - 1 - this._arrivalWaypointSize; i++) {
+            enRouteWaypoints.push(this._waypoints[this._currentFlightPlanIndex][i]);
+            if (outFPIndex) {
+                outFPIndex.push(i);
+            }
+        }
+        return enRouteWaypoints;
+    }
+    getEnRouteWaypointsLastIndex() {
+        return this.getDepartureWaypointsCount() + this.getEnRouteWaypoints().length;
+    }
+    getArrivalWaypoints() {
+        let arrivalWaypoints = [];
+        let destination = this.getDestination();
+        if (destination) {
+            let destinationInfos = destination.infos;
+            if (destinationInfos instanceof AirportInfo) {
+                let arrival = destinationInfos.arrivals[this._arrivalProcIndex];
+                if (arrival) {
+                    let enRouteTransition = arrival.enRouteTransitions[0];
+                    if (arrival.enRouteTransitions.length > 0) {
+                    }
+                    if (enRouteTransition && enRouteTransition.legs) {
+                        for (let i = 0; i < enRouteTransition.legs.length; i++) {
+                            let wp = new WayPoint(this.instrument);
+                            wp.icao = enRouteTransition.legs[i].fixIcao;
+                            wp.ident = wp.icao.substr(7);
+                            arrivalWaypoints.push(wp);
+                        }
+                    }
+                    if (arrival && arrival.commonLegs) {
+                        for (let i = 0; i < arrival.commonLegs.length; i++) {
+                            let wp = new WayPoint(this.instrument);
+                            wp.icao = arrival.commonLegs[i].fixIcao;
+                            wp.ident = wp.icao.substr(7);
+                            arrivalWaypoints.push(wp);
+                        }
+                    }
+                    let runwayTransition = arrival.runwayTransitions[0];
+                    if (arrival.runwayTransitions.length > 0) {
+                    }
+                    if (runwayTransition && runwayTransition.legs) {
+                        for (let i = 0; i < runwayTransition.legs.length; i++) {
+                            let wp = new WayPoint(this.instrument);
+                            wp.icao = runwayTransition.legs[i].fixIcao;
+                            wp.ident = wp.icao.substr(7);
+                            arrivalWaypoints.push(wp);
+                        }
+                    }
+                }
+            }
+        }
+        return arrivalWaypoints;
+    }
+    getArrivalWaypointsMap() {
+        let arrivalWaypoints = [];
+        for (let i = this._waypoints[this._currentFlightPlanIndex].length - 1 - this._arrivalWaypointSize; i < this._waypoints[this._currentFlightPlanIndex].length - 1; i++) {
+            arrivalWaypoints.push(this._waypoints[this._currentFlightPlanIndex][i]);
+        }
+        return arrivalWaypoints;
+    }
+    getWaypointsWithAltitudeConstraints() {
+        let waypointsWithAltitudeConstraints = [];
+        for (let i = 0; i < this._waypoints[0].length; i++) {
+            let wp = this._waypoints[0][i];
+            if (wp.ident != "" && wp.legAltitudeDescription >= 1 && wp.legAltitude1 < 20000) {
+                waypointsWithAltitudeConstraints.push(wp);
+            }
+        }
+        let approachWaypoints = this.getApproachWaypoints();
+        for (let i = 0; i < approachWaypoints.length; i++) {
+            let apprWp = approachWaypoints[i];
+            if (apprWp.ident != "" && apprWp.legAltitudeDescription >= 1 && apprWp.legAltitude1 < 20000) {
+                waypointsWithAltitudeConstraints.push(apprWp);
+            }
+        }
+        return waypointsWithAltitudeConstraints;
+    }
+    setDestination(icao, callback = () => { }) {
+        Coherent.call("SET_DESTINATION", icao).then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    addWaypoint(icao, index = Infinity, callback = () => { }, setActive = true) {
+        if (index === Infinity) {
+            index = this._waypoints.length;
+        }
+        Coherent.call("ADD_WAYPOINT", icao, index, setActive).then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    setWaypointAltitude(altitude, index, callback = () => { }) {
+        Coherent.call("SET_WAYPOINT_ALTITUDE", altitude, index).then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    setWaypointAdditionalData(index, key, value, callback = () => { }) {
+        Coherent.call("SET_WAYPOINT_ADDITIONAL_DATA", index, key, value).then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    getWaypointAdditionalData(index, key, callback = () => { }) {
+        Coherent.call("GET_WAYPOINT_ADDITIONAL_DATA", index, key).then((value) => {
+            callback(value);
+        });
+    }
+    invertActiveFlightPlan(callback = () => { }) {
+        Coherent.call("INVERT_ACTIVE_FLIGHT_PLAN").then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    getApproachIfIcao(callback = () => { }) {
+        Coherent.call("GET_IF_ICAO").then((value) => {
+            callback(value);
+        });
+    }
+    addFlightPlanUpdateCallback(_callback) {
+        this._onFlightPlanUpdateCallbacks.push(_callback);
+    }
+    addWaypointByIdent(ident, index = Infinity, callback = EmptyCallback.Void) {
+        SimVar.SetSimVarValue("C:fs9gps:IcaoSearchStartCursor", "string", "WANV", "FMC").then(() => {
+            this.instrument.requestCall(() => {
+                SimVar.SetSimVarValue("C:fs9gps:IcaoSearchEnterChar", "string", ident, "FMC").then(() => {
+                    SimVar.SetSimVarValue("C:fs9gps:IcaoSearchMatchedIcao", "number", 0, "FMC").then(() => {
+                        let icao = SimVar.GetSimVarValue("C:fs9gps:IcaoSearchCurrentIcao", "string", "FMC");
+                        this.addWaypoint(icao, index, callback);
+                    });
+                });
+            });
+        });
+    }
+    removeWaypoint(index, thenSetActive = false, callback = () => { }) {
+        Coherent.call("REMOVE_WAYPOINT", index, thenSetActive).then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    indexOfWaypoint(waypoint) {
+        return this._waypoints[this._currentFlightPlanIndex].indexOf(waypoint);
+    }
+    getWaypointsCount(flightPlanIndex = NaN) {
+        if (isNaN(flightPlanIndex)) {
+            flightPlanIndex = this._currentFlightPlanIndex;
+        }
+        if (this._waypoints && this._waypoints[flightPlanIndex]) {
+            return this._waypoints[flightPlanIndex].length;
+        }
+        return 0;
+    }
+    getDepartureWaypointsCount() {
+        return this._departureWaypointSize;
+    }
+    getArrivalWaypointsCount() {
+        return this._arrivalWaypointSize;
+    }
+    getWaypoint(i, flightPlanIndex = NaN, considerApproachWaypoints) {
+        if (isNaN(flightPlanIndex)) {
+            flightPlanIndex = this._currentFlightPlanIndex;
+        }
+        if (!considerApproachWaypoints || i < this.getWaypointsCount() - 1) {
+            return this._waypoints[flightPlanIndex][i];
+        }
+        else {
+            let approachWaypoints = this.getApproachWaypoints();
+            let apprWp = approachWaypoints[i - (this.getWaypointsCount() - 1)];
+            if (apprWp) {
+                return apprWp;
+            }
+            return this.getDestination();
+        }
+    }
+    getWaypoints(flightPlanIndex = NaN) {
+        if (isNaN(flightPlanIndex)) {
+            flightPlanIndex = this._currentFlightPlanIndex;
+        }
+        return this._waypoints[flightPlanIndex];
+    }
+    getDepartureRunwayIndex() {
+        return this._departureRunwayIndex;
+    }
+    getDepartureRunway() {
+        let origin = this.getOrigin();
+        if (origin) {
+            let departure = this.getDeparture();
+            let infos = origin.infos;
+            if (infos instanceof AirportInfo) {
+                if (departure) {
+                    if (departure.runwayTransitions[this.getDepartureRunwayIndex()]) {
+                        let depRunway = departure.runwayTransitions[this.getDepartureRunwayIndex()].name.replace("RW", "");
+                        let runway = infos.oneWayRunways.find(r => { return r.designation.indexOf(depRunway) !== -1; });
+                        if (runway) {
+                            return runway;
+                        }
+                    }
+                    return undefined;
+                }
+                if (this._runwayIndex >= 0) {
+                    return infos.oneWayRunways[this._runwayIndex];
+                }
+            }
+        }
+    }
+    getDetectedCurrentRunway() {
+        let origin = this.getOrigin();
+        if (origin && origin.infos instanceof AirportInfo) {
+            let runways = origin.infos.oneWayRunways;
+            if (runways && runways.length > 0) {
+                let direction = Simplane.getHeadingMagnetic();
+                let bestRunway = runways[0];
+                let bestDeltaAngle = Math.abs(Avionics.Utils.angleDiff(direction, bestRunway.direction));
+                for (let i = 1; i < runways.length; i++) {
+                    let deltaAngle = Math.abs(Avionics.Utils.angleDiff(direction, runways[i].direction));
+                    if (deltaAngle < bestDeltaAngle) {
+                        bestDeltaAngle = deltaAngle;
+                        bestRunway = runways[i];
+                    }
+                }
+                return bestRunway;
+            }
+        }
+        return undefined;
+    }
+    getDepartureProcIndex() {
+        return this._departureProcIndex;
+    }
+    setDepartureProcIndex(index, callback = () => { }) {
+        Coherent.call("SET_DEPARTURE_PROC_INDEX", index).then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    setDepartureRunwayIndex(index, callback = EmptyCallback.Void) {
+        Coherent.call("SET_DEPARTURE_RUNWAY_INDEX", index).then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    setOriginRunwayIndex(index, callback = EmptyCallback.Void) {
+        Coherent.call("SET_ORIGIN_RUNWAY_INDEX", index).then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    getDepartureEnRouteTransitionIndex() {
+        return this._departureEnRouteTransitionIndex;
+    }
+    setDepartureEnRouteTransitionIndex(index, callback = EmptyCallback.Void) {
+        Coherent.call("SET_DEPARTURE_ENROUTE_TRANSITION_INDEX", index).then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    getDepartureDiscontinuity() {
+        return this._departureDiscontinuity;
+    }
+    clearDepartureDiscontinuity(callback = EmptyCallback.Void) {
+        Coherent.call("CLEAR_DEPARTURE_DISCONTINUITY").then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    removeDeparture(callback = () => { }) {
+        Coherent.call("REMOVE_DEPARTURE_PROC").then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    getArrivalProcIndex() {
+        return this._arrivalProcIndex;
+    }
+    getArrivalTransitionIndex() {
+        return this._arrivalTransitionIndex;
+    }
+    setArrivalProcIndex(index, callback = () => { }) {
+        Coherent.call("SET_ARRIVAL_PROC_INDEX", index).then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    getArrivalDiscontinuity() {
+        return this._arrivalDiscontinuity;
+    }
+    clearArrivalDiscontinuity(callback = EmptyCallback.Void) {
+        Coherent.call("CLEAR_ARRIVAL_DISCONTINUITY").then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    setArrivalEnRouteTransitionIndex(index, callback = () => { }) {
+        Coherent.call("SET_ARRIVAL_ENROUTE_TRANSITION_INDEX", index).then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    setArrivalRunwayIndex(index, callback = () => { }) {
+        Coherent.call("SET_ARRIVAL_RUNWAY_INDEX", index).then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    getApproachIndex() {
+        return this._approachIndex;
+    }
+    setApproachIndex(index, callback = () => { }, transition = 0) {
+        Coherent.call("SET_APPROACH_INDEX", index).then(() => {
+            Coherent.call("SET_APPROACH_TRANSITION_INDEX", transition).then(() => {
+                this.updateFlightPlan(() => {
+                    this.updateCurrentApproach(() => {
+                        callback();
+                    });
+                });
+            });
+        });
+        SimVar.SetSimVarValue("C:fs9gps:FlightPlanNewApproachAirport", "string", this.getDestination().icao);
+        SimVar.SetSimVarValue("C:fs9gps:FlightPlanNewApproachApproach", "number", index);
+        SimVar.SetSimVarValue("C:fs9gps:FlightPlanNewApproachTransition", "number", transition);
+        SimVar.SetSimVarValue("C:fs9gps:FlightPlanLoadApproach", "number", 1);
+    }
+    isLoadedApproach(forceSimVarCall = false) {
+        let doSimVarCall = false;
+        let t = 0;
+        if (forceSimVarCall || this._isLoadedApproach === undefined) {
+            doSimVarCall = true;
+        }
+        else {
+            t = performance.now();
+            if (t - this._isLoadedApproachTimeLastSimVarCall > 1000) {
+                doSimVarCall = true;
+            }
+        }
+        if (doSimVarCall) {
+            this._isLoadedApproach = SimVar.GetSimVarValue("C:fs9gps:FlightPlanIsLoadedApproach", "Bool");
+            this._isLoadedApproachTimeLastSimVarCall = t;
+        }
+        return this._isLoadedApproach;
+    }
+    isActiveApproach(forceSimVarCall = false) {
+        let doSimVarCall = false;
+        let t = 0;
+        if (forceSimVarCall || this._isActiveApproach === undefined) {
+            doSimVarCall = true;
+        }
+        else {
+            t = performance.now();
+            if (t - this._isActiveApproachTimeLastSimVarCall > 1000) {
+                doSimVarCall = true;
+            }
+        }
+        if (doSimVarCall) {
+            this._isActiveApproach = SimVar.GetSimVarValue("C:fs9gps:FlightPlanIsActiveApproach", "Bool");
+            this._isActiveApproachTimeLastSimVarCall = t;
+        }
+        return this._isActiveApproach;
+    }
+    isApproachActivated() {
+        return SimVar.GetSimVarValue("L:FLIGHT_PLAN_MANAGER_APPROACH_ACTIVATED", "boolean");
+    }
+    activateApproach(callback = EmptyCallback.Void) {
+        if (!this.isLoadedApproach()) {
+            callback();
+            return;
+        }
+        if (this.isActiveApproach()) {
+            this._approachActivated = true;
+            SimVar.SetSimVarValue("L:FLIGHT_PLAN_MANAGER_APPROACH_ACTIVATED", "boolean", true);
+            callback();
+            return;
+        }
+        Coherent.call("ACTIVATE_APPROACH").then(() => {
+            this._approachActivated = true;
+            SimVar.SetSimVarValue("L:FLIGHT_PLAN_MANAGER_APPROACH_ACTIVATED", "boolean", true);
+            this.updateCurrentApproach(() => {
+                callback();
+            });
+        });
+    }
+    deactivateApproach() {
+        Coherent.call("DEACTIVATE_APPROACH").then(() => {
+            this._approachActivated = false;
+            SimVar.SetSimVarValue("L:FLIGHT_PLAN_MANAGER_APPROACH_ACTIVATED", "boolean", false);
+        });
+    }
+    tryAutoActivateApproach() {
+        Coherent.call("TRY_AUTOACTIVATE_APPROACH").then(() => {
+            this._approachActivated = this._approachActivated || this.isActiveApproach();
+            SimVar.SetSimVarValue("L:FLIGHT_PLAN_MANAGER_APPROACH_ACTIVATED", "boolean", this._approachActivated);
+        });
+    }
+    getApproachActiveWaypointIndex() {
+        return this._approachActivated ? this.getActiveWaypointIndex() : -1;
+    }
+    getApproach() {
+        if (!this._approach) {
+            this._approach = new Approach();
+        }
+        return this._approach;
+    }
+    getApproachNavFrequency() {
+        if (this._approachIndex >= 0) {
+            let destination = this.getDestination();
+            let approachName = this.getApproach().runway;
+            if (destination) {
+                if (destination.infos instanceof AirportInfo) {
+                    let frequency = destination.infos.frequencies.find(f => {
+                        return f.name.replace("RW0", "").replace("RW", "").indexOf(approachName) !== -1;
+                    });
+                    if (frequency) {
+                        return frequency.mhValue;
+                    }
+                }
+            }
+        }
+        return NaN;
+    }
+    getApproachTransitionIndex() {
+        return this._approachTransitionIndex;
+    }
+    getLastIndexBeforeApproach() {
+        return this._lastIndexBeforeApproach;
+    }
+    getApproachRunway() {
+        let destination = this.getDestination();
+        if (destination) {
+            let infos = destination.infos;
+            if (infos instanceof AirportInfo) {
+                let approach = infos.approaches[this._approachIndex];
+                if (approach) {
+                    let runway = infos.oneWayRunways.find(r => { return r.designation.indexOf(approach.runway.replace(" ", "")) !== -1; });
+                    return runway;
+                }
+            }
+        }
+    }
+    getApproachWaypoints() {
+        return this._approachWaypoints;
+        let waypoints = [];
+        let airportApproach = this.getApproach();
+        let transition;
+        if (airportApproach) {
+            let transitionIndex = this.getApproachTransitionIndex();
+            transition = airportApproach.transitions[transitionIndex];
+            if (!transition) {
+                transition = airportApproach.transitions[0];
+            }
+        }
+        if (airportApproach && transition) {
+            for (let i = (this.getArrivalProcIndex() == -1 ? 0 : 1); i < transition.waypoints.length - 1; i++) {
+                waypoints.push(transition.waypoints[i]);
+            }
+        }
+        return waypoints;
+    }
+    setApproachTransitionIndex(index, callback = () => { }) {
+        Coherent.call("SET_APPROACH_TRANSITION_INDEX", index).then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    removeArrival(callback = () => { }) {
+        Coherent.call("REMOVE_ARRIVAL_PROC").then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    activateDirectTo(icao, callback = EmptyCallback.Void) {
+        Coherent.call("ACTIVATE_DIRECT_TO", icao).then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    cancelDirectTo(callback = EmptyCallback.Void) {
+        Coherent.call("CANCEL_DIRECT_TO").then(() => {
+            this.updateFlightPlan(callback);
+        });
+    }
+    getIsDirectTo() {
+        return this._isDirectTo;
+    }
+    getDirectToTarget() {
+        return this._directToTarget;
+    }
+    getDirecToOrigin() {
+        return this._directToOrigin;
+    }
+    getCoordinatesHeadingAtDistanceAlongFlightPlan(distance) {
+        let prevWaypoint = this.getPreviousActiveWaypoint();
+        let nextWaypoint = this.getActiveWaypoint();
+        if (prevWaypoint && nextWaypoint) {
+            let planeCoordinates = new LatLong(SimVar.GetSimVarValue("PLANE LATITUDE", "degree latitude"), SimVar.GetSimVarValue("PLANE LONGITUDE", "degree longitude"));
+            let a = Avionics.Utils.computeGreatCircleDistance(planeCoordinates, prevWaypoint.infos.coordinates);
+            let b = Avionics.Utils.computeGreatCircleDistance(planeCoordinates, nextWaypoint.infos.coordinates);
+            let f = a / (a + b);
+            let dActiveLeg = (1 - f) * Avionics.Utils.computeGreatCircleDistance(prevWaypoint.infos.coordinates, nextWaypoint.infos.coordinates);
+            if (distance <= dActiveLeg) {
+                let ff = distance / dActiveLeg;
+                let startLat = Avionics.Utils.lerpAngle(prevWaypoint.infos.lat, nextWaypoint.infos.lat, f);
+                let startLong = Avionics.Utils.lerpAngle(prevWaypoint.infos.long, nextWaypoint.infos.long, f);
+                let targetLat = Avionics.Utils.lerpAngle(startLat, nextWaypoint.infos.lat, ff);
+                let targetLong = Avionics.Utils.lerpAngle(startLong, nextWaypoint.infos.long, ff);
+                return { lla: new LatLong(targetLat, targetLong), heading: nextWaypoint.bearingInFP };
+            }
+            distance -= dActiveLeg;
+            let index = this.getActiveWaypointIndex() + 1;
+            let done = false;
+            let currentLegLength = NaN;
+            while (!done) {
+                nextWaypoint = this.getWaypoint(index);
+                prevWaypoint = this.getWaypoint(index - 1);
+                if (nextWaypoint && prevWaypoint) {
+                    currentLegLength = Avionics.Utils.computeGreatCircleDistance(prevWaypoint.infos.coordinates, nextWaypoint.infos.coordinates);
+                    if (currentLegLength < distance) {
+                        distance -= currentLegLength;
+                        index++;
+                    }
+                    else {
+                        done = true;
+                    }
+                }
+                else {
+                    done = true;
+                }
+            }
+            if (nextWaypoint && prevWaypoint && isFinite(currentLegLength)) {
+                let ff = distance / currentLegLength;
+                let targetLat = Avionics.Utils.lerpAngle(prevWaypoint.infos.lat, nextWaypoint.infos.lat, ff);
+                let targetLong = Avionics.Utils.lerpAngle(prevWaypoint.infos.long, nextWaypoint.infos.long, ff);
+                return { lla: new LatLong(targetLat, targetLong), heading: nextWaypoint.bearingInFP };
+            }
+            return { lla: new LatLong(this.getDestination().infos.coordinates), heading: 0 };
+        }
+        return undefined;
+    }
+    getCoordinatesAtNMFromDestinationAlongFlightPlan(distance) {
+        let allWaypoints = [...this.getWaypoints()];
+        let last = allWaypoints.pop();
+        allWaypoints.push(...this.getApproachWaypoints());
+        allWaypoints.push(last);
+        let destination = this.getDestination();
+        if (destination) {
+            let fromStartDistance = destination.cumulativeDistanceInFP - distance;
+            let prevIndex;
+            let prev;
+            let next;
+            for (let i = 0; i < allWaypoints.length - 1; i++) {
+                prevIndex = i;
+                prev = allWaypoints[i];
+                next = allWaypoints[i + 1];
+                if (prev.cumulativeDistanceInFP < fromStartDistance && next.cumulativeDistanceInFP > fromStartDistance) {
+                    break;
+                }
+            }
+            let prevCD = prev.cumulativeDistanceInFP;
+            let nextCD = next.cumulativeDistanceInFP;
+            let d = (fromStartDistance - prevCD) / (nextCD - prevCD);
+            let output = new LatLong();
+            output.lat = Avionics.Utils.lerpAngle(prev.infos.coordinates.lat, next.infos.coordinates.lat, d);
+            output.long = Avionics.Utils.lerpAngle(prev.infos.coordinates.long, next.infos.coordinates.long, d);
+            return {
+                lla: output,
+                prevIndex: prevIndex
+            };
+        }
+    }
+}
+//# sourceMappingURL=FlightPlanManager.js.map

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/AttitudeIndicator.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/AttitudeIndicator.js
@@ -618,14 +618,14 @@ var Jet_PFD_FlightDirector;
                     if (fdPhase < 1) {
                         currentFDPitch = -8;
                     }
-                    if ((fdPhase == 1) || altAboveGround > 5) {
-                        currentFDPitch = -12.5 ;
+                    if (((fdPhase == 1) || altAboveGround > 5) && Simplane.getIndicatedSpeed() > 80) {
+                        currentFDPitch = -11 ;
                         SimVar.SetSimVarValue("L:SALTY_FD_TAKEOFF_PHASE", "Enum", 1);
                     }
                     if ((vertSpeed >= 600 || fdPhase == 2) && altAboveGround > 10) {  
                         SimVar.SetSimVarValue("K:FLIGHT_LEVEL_CHANGE_ON", "Number", 1);
-                        let blendfactor = (vertSpeed - 600) / 80;
-                        currentFDPitch = Simplane.getFlightDirectorPitch() - 15 + blendfactor;
+                        let blendfactor = (vertSpeed - 600) / 200;
+                        currentFDPitch = Simplane.getFlightDirectorPitch() - 11 + blendfactor;
                         SimVar.SetSimVarValue("L:SALTY_FD_TAKEOFF_PHASE", "Enum", 2);
                     }
                     if ((vertSpeed >= 1200 || fdPhase == 3) && altAboveGround > 10) {  

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/AttitudeIndicator.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/AttitudeIndicator.js
@@ -619,13 +619,13 @@ var Jet_PFD_FlightDirector;
                         currentFDPitch = -8;
                     }
                     if (((fdPhase == 1) || altAboveGround > 5) && Simplane.getIndicatedSpeed() > 80) {
-                        currentFDPitch = -11 ;
+                        currentFDPitch = -10 ;
                         SimVar.SetSimVarValue("L:SALTY_FD_TAKEOFF_PHASE", "Enum", 1);
                     }
                     if ((vertSpeed >= 600 || fdPhase == 2) && altAboveGround > 10) {  
                         SimVar.SetSimVarValue("K:FLIGHT_LEVEL_CHANGE_ON", "Number", 1);
-                        let blendfactor = (vertSpeed - 600) / 200;
-                        currentFDPitch = Simplane.getFlightDirectorPitch() - 11 + blendfactor;
+                        let blendfactor = (vertSpeed - 600) / 350;
+                        currentFDPitch = Simplane.getFlightDirectorPitch() - 7 + blendfactor;
                         SimVar.SetSimVarValue("L:SALTY_FD_TAKEOFF_PHASE", "Enum", 2);
                     }
                     if ((vertSpeed >= 1200 || fdPhase == 3) && altAboveGround > 10) {  

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js
@@ -385,7 +385,7 @@ var Boeing_FMA;
             if (SimVar.GetSimVarValue("L:AP_VNAV_ACTIVE", "number") === 1) {
                 if (Simplane.getAutoPilotAltitudeLockActive()) {
                     let altitude = Simplane.getAltitude();
-                    if (altitude > SimVar.GetSimVarValue("L:AIRLINER_CRUISE_ALTITUDE", "number") + 100) {
+                    if (Math.abs(altitude - SimVar.GetSimVarValue("L:AIRLINER_CRUISE_ALTITUDE", "number")) >= 100) {
                         return 9;
                     }
                     return 7;

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js
@@ -383,12 +383,12 @@ var Boeing_FMA;
                 return 6;
             }
             if (SimVar.GetSimVarValue("L:AP_VNAV_ACTIVE", "number") === 1) {
+                //When capturing in VNAV, triggers VNAV ALT if in conflict with MCP altitude
                 if (Simplane.getAutoPilotAltitudeLockActive()) {
-                    //When capturing in VNAV, triggers VNAV ALT if in conflict with MCP altitude
-                    if (Math.abs(Simplane.getAutoPilotSelectedAltitudeLockValue("feet") - SimVar.GetSimVarValue("L:AIRLINER_CRUISE_ALTITUDE", "number")) >= 100) {
-                        return 9;
+                    if (SimVar.GetSimVarValue("L:AP_CURRENT_TARGET_ALTITUDE_IS_CONSTRAINT", "number")) {
+                        return 7;
                     }
-                    return 7;
+                    return 9;
                 }
                 return 8;
             }

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js
@@ -384,8 +384,7 @@ var Boeing_FMA;
             }
             if (SimVar.GetSimVarValue("L:AP_VNAV_ACTIVE", "number") === 1) {
                 if (Simplane.getAutoPilotAltitudeLockActive()) {
-                    let altitude = Simplane.getAltitude();
-                    if (Math.abs(altitude - SimVar.GetSimVarValue("L:AIRLINER_CRUISE_ALTITUDE", "number")) >= 100) {
+                    if (Math.abs(Simplane.getAutoPilotSelectedAltitudeLockValue("feet") - SimVar.GetSimVarValue("L:AIRLINER_CRUISE_ALTITUDE", "number")) >= 100) {
                         return 9;
                     }
                     return 7;

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js
@@ -384,6 +384,7 @@ var Boeing_FMA;
             }
             if (SimVar.GetSimVarValue("L:AP_VNAV_ACTIVE", "number") === 1) {
                 if (Simplane.getAutoPilotAltitudeLockActive()) {
+                    //When capturing in VNAV, triggers VNAV ALT if in conflict with MCP altitude
                     if (Math.abs(Simplane.getAutoPilotSelectedAltitudeLockValue("feet") - SimVar.GetSimVarValue("L:AIRLINER_CRUISE_ALTITUDE", "number")) >= 100) {
                         return 9;
                     }

--- a/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js
+++ b/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js
@@ -236,14 +236,11 @@ var Boeing_FMA;
             if (ApproachStatus.isRolloutActive) {
                 return 7;
             }
-            if (Simplane.getEngineThrottleMode(0) === ThrottleMode.TOGA || Simplane.getCurrentFlightPhase() <= FlightPhase.FLIGHT_PHASE_TAKEOFF) {
+            if (Simplane.getCurrentFlightPhase() === FlightPhase.FLIGHT_PHASE_TAKEOFF && SimVar.GetSimVarValue("L:AP_LNAV_ACTIVE", "number" ) === 0) {
                 return 8;
             }
             if (SimVar.GetSimVarValue("L:AP_LNAV_ACTIVE", "number") === 1) {
                 return 5;
-            }
-            if (Simplane.getEngineThrottleMode(0) === ThrottleMode.HOLD && SimVar.GetSimVarValue("L:AP_LNAV_ARMED", "number") === 1) {
-                return 8;
             }
             if (Simplane.getAutoPilotHeadingLockActive()) {
                 if (SimVar.GetSimVarValue("L:AP_HEADING_HOLD_ACTIVE", "number") === 1) {
@@ -382,7 +379,7 @@ var Boeing_FMA;
                     return 4;
                 }
             }
-            if (Simplane.getEngineThrottleMode(0) === ThrottleMode.TOGA || Simplane.getCurrentFlightPhase() <= FlightPhase.FLIGHT_PHASE_TAKEOFF) {
+            if (Simplane.getCurrentFlightPhase() === FlightPhase.FLIGHT_PHASE_TAKEOFF && SimVar.GetSimVarValue("L:AP_VNAV_ACTIVE", "number" ) === 0) {
                 return 6;
             }
             if (SimVar.GetSimVarValue("L:AP_VNAV_ACTIVE", "number") === 1) {
@@ -394,9 +391,6 @@ var Boeing_FMA;
                     return 7;
                 }
                 return 8;
-            }
-            if (Simplane.getEngineThrottleMode(0) === ThrottleMode.HOLD && SimVar.GetSimVarValue("L:AP_VNAV_ARMED", "number") === 1) {
-                return 6;
             }
             if (SimVar.GetSimVarValue("L:AP_FLCH_ACTIVE", "number") === 1) {
                 return 2;

--- a/layout.json
+++ b/layout.json
@@ -3,287 +3,297 @@
         {
             "path": "html_ui/Pages/Salty/SaltyBase.js",
             "size": 182,
-            "date": 132532153637782998
+            "date": 132481255336780588
         },
         {
             "path": "html_ui/Pages/Salty/SaltyIRS.js",
             "size": 1607,
-            "date": 132532153637782998
+            "date": 132481255336790588
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.html",
             "size": 3721,
-            "date": 132532153637793000
+            "date": 132527553168219162
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.js",
             "size": 9084,
-            "date": 132543533596005964
+            "date": 132553938900724730
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.css",
             "size": 1102,
-            "date": 132532153637793000
+            "date": 132552874392232988
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.html",
             "size": 4247,
-            "date": 132532153637793000
+            "date": 132552874392242976
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.js",
             "size": 2526,
-            "date": 132532153637793000
+            "date": 132481255336820596
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_ELEC.css",
             "size": 1883,
-            "date": 132532153637802976
+            "date": 132552874392303000
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_ELEC.html",
             "size": 14074,
-            "date": 132532153637802976
+            "date": 132552874392353008
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_ELEC.js",
             "size": 22325,
-            "date": 132532153637802976
+            "date": 132481255336830596
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_FCTL.css",
             "size": 1085,
-            "date": 132532153637812980
+            "date": 132481255336830596
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_FCTL.html",
             "size": 11319,
-            "date": 132532153637812980
+            "date": 132552874392363014
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_FCTL.js",
             "size": 8580,
-            "date": 132532153637812980
+            "date": 132481255336840600
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_GEAR.css",
             "size": 1388,
-            "date": 132532153637812980
+            "date": 132481255336840600
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_GEAR.html",
             "size": 7826,
-            "date": 132532153637812980
+            "date": 132552874392413020
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_GEAR.js",
             "size": 1599,
-            "date": 132532153637822984
+            "date": 132481255336850602
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Stat.css",
             "size": 1026,
-            "date": 132532153637822984
+            "date": 132552874392423018
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Stat.html",
             "size": 3122,
-            "date": 132532153637822984
+            "date": 132481255336860604
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Stat.js",
             "size": 2177,
-            "date": 132532153637822984
+            "date": 132481255336860604
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC.html",
-            "size": 5017,
-            "date": 132543534140974330
+            "size": 5046,
+            "date": 132554536946754400
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js",
-            "size": 37615,
-            "date": 132543534834985660
+            "size": 37723,
+            "date": 132554506279591642
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplayPages.js",
             "size": 1810,
-            "date": 132543533596005964
+            "date": 132553938900744740
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_PerfInitPage.js",
             "size": 3872,
-            "date": 132543533596015954
+            "date": 132553938900744740
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_ProgPage.js",
             "size": 8247,
-            "date": 132543535095427038
+            "date": 132553938900754738
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_SaltyOptions.js",
             "size": 1274,
-            "date": 132532153637842986
+            "date": 132527553168289578
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_TakeOffPage.js",
             "size": 5259,
-            "date": 132543533596015954
+            "date": 132553938900754738
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_VNAVPage.js",
             "size": 5234,
-            "date": 132543533596015954
+            "date": 132553938900764750
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js",
+            "size": 21254,
+            "date": 132550146092317082
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js",
+            "size": 100726,
+            "date": 132550146096948134
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.html",
             "size": 10070,
-            "date": 132532153637853000
+            "date": 132552874392483038
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.js",
-            "size": 26073,
-            "date": 132532153638182990
+            "size": 26065,
+            "date": 132553938900824752
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/Salty_BaseNDCompass.js",
             "size": 39839,
-            "date": 132543533596025954
+            "date": 132553938900824752
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/Salty_NDCompass.js",
             "size": 48771,
-            "date": 132543533596025954
+            "date": 132553938900834766
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/AirspeedIndicator.js",
             "size": 67001,
-            "date": 132543533596035954
+            "date": 132553938900844768
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/AttitudeIndicator.js",
             "size": 41357,
-            "date": 132543533596035954
+            "date": 132553938900854760
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.css",
             "size": 3841,
-            "date": 132532153638202974
+            "date": 132552874392523040
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.html",
             "size": 5919,
-            "date": 132532153638202974
+            "date": 132552874392583076
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.js",
             "size": 9722,
-            "date": 132543533596045962
+            "date": 132553938900854760
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.css",
             "size": 3753,
-            "date": 132532153638212984
+            "date": 132552874392583076
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.html",
             "size": 1191,
-            "date": 132532153638212984
+            "date": 132484024209908882
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js",
             "size": 18979,
-            "date": 132532153638212984
+            "date": 132481255336950626
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/SAI/B747_8_SAI.html",
             "size": 5882,
-            "date": 132532153638222998
+            "date": 132522423698640504
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/SAI/B747_8_SAI.js",
             "size": 64853,
-            "date": 132532153638222998
+            "date": 132552874392603068
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/approach.FLT",
             "size": 5285,
-            "date": 132543533595965960
+            "date": 132553938900654716
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/apron.FLT",
             "size": 5152,
-            "date": 132543533595965960
+            "date": 132553938900654716
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/Climb.flt",
             "size": 5290,
-            "date": 132543533595955960
+            "date": 132553938900644712
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/cruise.FLT",
             "size": 5285,
-            "date": 132543533595965960
+            "date": 132553938900664726
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/engines.cfg",
             "size": 7132,
-            "date": 132543533595975956
+            "date": 132553938900664726
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/final.FLT",
             "size": 5293,
-            "date": 132543533595975956
+            "date": 132553938900674726
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/flight_model.cfg",
             "size": 44784,
-            "date": 132543533595975956
+            "date": 132553938900674726
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/hangar.flt",
             "size": 4264,
-            "date": 132543533595985956
+            "date": 132553938900684726
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/runway.FLT",
             "size": 5150,
-            "date": 132543533595996136
+            "date": 132553938900714738
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/taxi.FLT",
             "size": 5079,
-            "date": 132543533595996136
+            "date": 132553938900714738
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/model/747_8I_INTERIOR.xml",
             "size": 189921,
-            "date": 132543533595985956
+            "date": 132553938900694738
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/panel/panel.cfg",
             "size": 2508,
-            "date": 132543531610166428
+            "date": 132481255336750582
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/panel/panel.xml",
             "size": 23083,
-            "date": 132543533595996136
+            "date": 132553938900704736
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/TEXTURE/B747_COCKPIT_TEXTS_EMISSIVE.TIF.DDS",
             "size": 4194432,
-            "date": 132532153637162998
+            "date": 132481808335640110
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/TEXTURE/B747_COCKPIT_TEXTS_EMISSIVE.TIF.DDS.json",
             "size": 102,
-            "date": 132532153637173016
+            "date": 132481808335650116
         },
         {
             "path": "ModelBehaviorDefs/Asobo/Airliner/Boeing.xml",
             "size": 46602,
-            "date": 132543533595955960
+            "date": 132553938900593502
         }
     ]
 }

--- a/layout.json
+++ b/layout.json
@@ -12,13 +12,18 @@
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.html",
-            "size": 3721,
-            "date": 132527553168219162
+            "size": 3736,
+            "date": 132555741309869918
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.js",
             "size": 9084,
             "date": 132553938900724730
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Boeing_Common.js",
+            "size": 25280,
+            "date": 132550146092897222
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.css",
@@ -98,12 +103,12 @@
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC.html",
             "size": 5046,
-            "date": 132554536946754400
+            "date": 132555620212671952
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js",
-            "size": 37615,
-            "date": 132554596911235784
+            "size": 39232,
+            "date": 132555737538148928
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplayPages.js",
@@ -118,7 +123,7 @@
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_ProgPage.js",
             "size": 8247,
-            "date": 132553938900754738
+            "date": 132555620212691956
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_SaltyOptions.js",
@@ -137,13 +142,13 @@
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js",
-            "size": 21251,
-            "date": 132554612453214238
+            "size": 21320,
+            "date": 132555677367008886
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js",
-            "size": 100654,
-            "date": 132554612410739382
+            "size": 100791,
+            "date": 132555737637057090
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.html",
@@ -172,8 +177,8 @@
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/AttitudeIndicator.js",
-            "size": 41357,
-            "date": 132553938900854760
+            "size": 42683,
+            "date": 132555696284599100
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.css",
@@ -202,8 +207,8 @@
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js",
-            "size": 18979,
-            "date": 132481255336950626
+            "size": 18726,
+            "date": 132555620212811592
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/SAI/B747_8_SAI.html",

--- a/layout.json
+++ b/layout.json
@@ -13,27 +13,27 @@
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.html",
             "size": 3736,
-            "date": 132555741309869918
+            "date": 132556583967532052
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.js",
             "size": 9084,
-            "date": 132553938900724730
+            "date": 132556583967542050
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Boeing_Common.js",
-            "size": 25280,
-            "date": 132550146092897222
+            "size": 25692,
+            "date": 132556583967551108
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.css",
             "size": 1102,
-            "date": 132552874392232988
+            "date": 132556583856416698
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.html",
             "size": 4247,
-            "date": 132552874392242976
+            "date": 132556583856416698
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_DRS.js",
@@ -43,12 +43,12 @@
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_ELEC.css",
             "size": 1883,
-            "date": 132552874392303000
+            "date": 132556583856426700
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_ELEC.html",
             "size": 14074,
-            "date": 132552874392353008
+            "date": 132556583856436700
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_ELEC.js",
@@ -63,7 +63,7 @@
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_FCTL.html",
             "size": 11319,
-            "date": 132552874392363014
+            "date": 132556583856442754
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_FCTL.js",
@@ -78,7 +78,7 @@
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_GEAR.html",
             "size": 7826,
-            "date": 132552874392413020
+            "date": 132556583856442754
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_GEAR.js",
@@ -88,7 +88,7 @@
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Stat.css",
             "size": 1026,
-            "date": 132552874392423018
+            "date": 132556583856452422
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Stat.html",
@@ -102,28 +102,28 @@
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC.html",
-            "size": 5046,
-            "date": 132555620212671952
+            "size": 5061,
+            "date": 132556617338104082
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js",
-            "size": 39232,
-            "date": 132555737538148928
+            "size": 41095,
+            "date": 132556583967571074
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplayPages.js",
             "size": 1810,
-            "date": 132553938900744740
+            "date": 132556583967571074
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_PerfInitPage.js",
             "size": 3872,
-            "date": 132553938900744740
+            "date": 132556583967581076
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_ProgPage.js",
             "size": 8247,
-            "date": 132555620212691956
+            "date": 132556583967581076
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_SaltyOptions.js",
@@ -133,72 +133,77 @@
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_TakeOffPage.js",
             "size": 5259,
-            "date": 132554607475284266
+            "date": 132556583967591080
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_VNAVPage.js",
-            "size": 5234,
-            "date": 132553938900764750
+            "size": 5613,
+            "date": 132556583967601078
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js",
             "size": 21320,
-            "date": 132555677367008886
+            "date": 132556616109723936
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FlightPlanManager.js",
+            "size": 68077,
+            "date": 132556550116783300
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js",
-            "size": 100791,
-            "date": 132555737637057090
+            "size": 100808,
+            "date": 132556583967611092
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.html",
             "size": 10070,
-            "date": 132552874392483038
+            "date": 132556583856502398
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.js",
             "size": 26065,
-            "date": 132553938900824752
+            "date": 132556583967681122
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/Salty_BaseNDCompass.js",
             "size": 39839,
-            "date": 132553938900824752
+            "date": 132556583967681122
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/Salty_NDCompass.js",
             "size": 48771,
-            "date": 132553938900834766
+            "date": 132556583967691134
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/AirspeedIndicator.js",
             "size": 67001,
-            "date": 132553938900844768
+            "date": 132556583967711132
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/AttitudeIndicator.js",
-            "size": 42683,
-            "date": 132555696284599100
+            "size": 42682,
+            "date": 132556583967711132
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.css",
             "size": 3841,
-            "date": 132552874392523040
+            "date": 132556583856552412
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.html",
             "size": 5919,
-            "date": 132552874392583076
+            "date": 132556583856552412
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/B747_8_PFD.js",
             "size": 9722,
-            "date": 132553938900854760
+            "date": 132556583967721134
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.css",
             "size": 3753,
-            "date": 132552874392583076
+            "date": 132556583856562412
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.html",
@@ -207,8 +212,8 @@
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/Boeing_FMA.js",
-            "size": 18726,
-            "date": 132555620212811592
+            "size": 18664,
+            "date": 132556583967731146
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/SAI/B747_8_SAI.html",
@@ -218,62 +223,62 @@
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/SAI/B747_8_SAI.js",
             "size": 64853,
-            "date": 132552874392603068
+            "date": 132556583856582418
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/approach.FLT",
             "size": 5285,
-            "date": 132553938900654716
+            "date": 132556583967451412
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/apron.FLT",
             "size": 5152,
-            "date": 132553938900654716
+            "date": 132556583967462082
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/Climb.flt",
             "size": 5290,
-            "date": 132553938900644712
+            "date": 132556583967451412
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/cruise.FLT",
             "size": 5285,
-            "date": 132553938900664726
+            "date": 132556583967462082
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/engines.cfg",
             "size": 7132,
-            "date": 132553938900664726
+            "date": 132556583967472038
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/final.FLT",
             "size": 5293,
-            "date": 132553938900674726
+            "date": 132556583967472038
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/flight_model.cfg",
             "size": 44784,
-            "date": 132553938900674726
+            "date": 132556583967482050
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/hangar.flt",
             "size": 4264,
-            "date": 132553938900684726
+            "date": 132556583967492042
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/runway.FLT",
             "size": 5150,
-            "date": 132553938900714738
+            "date": 132556583967522052
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/taxi.FLT",
             "size": 5079,
-            "date": 132553938900714738
+            "date": 132556583967522052
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/model/747_8I_INTERIOR.xml",
             "size": 189921,
-            "date": 132553938900694738
+            "date": 132556583967502046
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/panel/panel.cfg",
@@ -283,7 +288,7 @@
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/panel/panel.xml",
             "size": 23083,
-            "date": 132553938900704736
+            "date": 132556583967512052
         },
         {
             "path": "SimObjects/Airplanes/Asobo_B747_8i/TEXTURE/B747_COCKPIT_TEXTS_EMISSIVE.TIF.DDS",
@@ -298,7 +303,7 @@
         {
             "path": "ModelBehaviorDefs/Asobo/Airliner/Boeing.xml",
             "size": 46602,
-            "date": 132553938900593502
+            "date": 132556583967433208
         }
     ]
 }

--- a/layout.json
+++ b/layout.json
@@ -102,8 +102,8 @@
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js",
-            "size": 37723,
-            "date": 132554506279591642
+            "size": 37615,
+            "date": 132554596911235784
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplayPages.js",
@@ -128,7 +128,7 @@
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_TakeOffPage.js",
             "size": 5259,
-            "date": 132553938900754738
+            "date": 132554607475284266
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_VNAVPage.js",
@@ -137,13 +137,13 @@
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js",
-            "size": 21254,
-            "date": 132550146092317082
+            "size": 21251,
+            "date": 132554612453214238
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js",
-            "size": 100726,
-            "date": 132550146096948134
+            "size": 100654,
+            "date": 132554612410739382
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/MFD/B747_8_MFD.html",

--- a/manifest.json
+++ b/manifest.json
@@ -21,5 +21,5 @@
             "OlderHistory": ""
         }
     },
-    "total_package_size": "00000000000005213931"
+    "total_package_size": "00000000000005284631"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -21,5 +21,5 @@
             "OlderHistory": ""
         }
     },
-    "total_package_size": "00000000000005185740"
+    "total_package_size": "00000000000005213931"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -21,5 +21,5 @@
             "OlderHistory": ""
         }
     },
-    "total_package_size": "00000000000005185923"
+    "total_package_size": "00000000000005185740"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -21,5 +21,5 @@
             "OlderHistory": ""
         }
     },
-    "total_package_size": "00000000000005063814"
+    "total_package_size": "00000000000005185923"
 }


### PR DESCRIPTION
### **VNAV**
-----------------------------------------------------------------------
Aim to improve the default VNAV implementation in the 747-8.

Changes so far:

**Takeoff**

- Smoothed Flight Director pitch command during rotation with VNAV armed.

**Climb**

- Aircraft climbs out at V2 speed after rotation until 3000'. (Settable through L:AIRLINER_ACC_ALT)

- Thrust reduction is automatically scheduled at 1500'. (Settable through L:AIRLINER_THR_RED_ALT)
 
- Aircraft automatically accelerates at 3000'AGL to 5kts below current flap placard speed.

- Once Flaps up, VNAV commands climb speed of Flaps UP Manoeuvre Speed + 20kts (VREF30 + 100kts) 
  or 250kts whichever is greater.

**General**

- VNAV now respects altitude constraints for waypoint legs.

- Working VNAV ALT mode added, autopilot will now respect the MCP altitude when climbing in VNAV SPD and switch to VNAV 
  ALT mode upon reaching.

- When levelling in VNAV PTH or VNAV ALT, the autothrottle now activates correctly in SPD mode instead of THR.

**FMC**

- New VNAV CLB page showing CLB Speed, Speed Transition, Transition Altitude & Max Angle Climb Speed.
