### PR TITLE
Added SPEEDBRAKE ARMED Memo

### DIFF
--- a/SimObjects/Airplanes/Asobo_B747_8i/panel/panel.xml
+++ b/SimObjects/Airplanes/Asobo_B747_8i/panel/panel.xml
@@ -285,6 +285,17 @@
 
 		<Annunciation>
 		  <Type>Memo</Type>
+		  <Text>SPEEDBRAKE ARMED</Text>
+		  <Condition>
+		  	<Equal>
+				<Simvar name="SPOILERS ARMED" unit="Boolean"/>
+				<Constant>1</Constant>
+			</Equal>
+		  </Condition>
+		</Annunciation>
+
+		<Annunciation>
+		  <Type>Memo</Type>
 		  <Text>APU RUNNING</Text>
 		  <Condition>
 		    <GreaterEqual>


### PR DESCRIPTION
Since Asobo fixed the armed status of the Spoilers in the model, we are now able to add the missing SPEEDBRAKE ARMED memo message to the EICAS.