### PR TITLE
Set attributes util

### DIFF
--- a/salty-747/html_ui/Pages/Salty/SaltyUtils.js
+++ b/salty-747/html_ui/Pages/Salty/SaltyUtils.js
@@ -2,7 +2,7 @@ const SaltyUtils =  {
 
     setAttributes = (_elem, ..._attributes) => {
 
-        attributes.forEach(attrib => {
+        _attributes.forEach(attrib => {
             if (attrib.length === 2) {
                 _elem.setAttribute(attrib[0], attrib[1]);
             }

--- a/salty-747/html_ui/Pages/Salty/SaltyUtils.js
+++ b/salty-747/html_ui/Pages/Salty/SaltyUtils.js
@@ -1,0 +1,13 @@
+const SaltyUtils =  {
+
+    setAttributes = (_elem, _attributes) => {
+
+        attributes.forEach(attrib => {
+            if (attrib.length === 2) {
+                _elem.setAttribute(attrib[0], attrib[1]);
+            }
+        });
+    }
+
+    
+};

--- a/salty-747/html_ui/Pages/Salty/SaltyUtils.js
+++ b/salty-747/html_ui/Pages/Salty/SaltyUtils.js
@@ -1,13 +1,9 @@
 const SaltyUtils =  {
 
-    setAttributes = (_elem, ..._attributes) => {
-
-        _attributes.forEach(attrib => {
-            if (attrib.length === 2) {
-                _elem.setAttribute(attrib[0], attrib[1]);
-            }
-        });
+    setAttributes : (_elem, _attributes) => {
+        for (const attr in _attributes) {
+            _elem.setAttribute(attr, _attributes[attr]);
+        }
     }
 
-    
 };

--- a/salty-747/html_ui/Pages/Salty/SaltyUtils.js
+++ b/salty-747/html_ui/Pages/Salty/SaltyUtils.js
@@ -1,6 +1,6 @@
 const SaltyUtils =  {
 
-    setAttributes = (_elem, _attributes) => {
+    setAttributes = (_elem, ..._attributes) => {
 
         attributes.forEach(attrib => {
             if (attrib.length === 2) {

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.html
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/B747_8_EICAS.html
@@ -23,6 +23,8 @@
 
 <script type="text/html" import-script="/JS/SimPlane.js"></script>
 
+<script type="text/html" import-script="/Pages/Salty/SaltyUtils.js"></script>
+
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/Utils/RadioNav.js"></script>
 
 <script type="text/html" import-script="/Pages/VCockpit/Instruments/Shared/FlightElements/FlightPlan.js"></script>

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_EICASGauge.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_EICASGauge.js
@@ -127,7 +127,7 @@ var B747_8_EICAS_Common;
         }
         createRect(_x, _y, _width, _height, _class) {
             var rect = document.createElementNS(Avionics.SVG.NS, "rect");
-            
+
             SaltyUtils.setAttributes(rect, 
                 ['x', _x],
                 ['y', _y],
@@ -145,11 +145,15 @@ var B747_8_EICAS_Common;
             var y = this.valueToGaugePosY(_lineDef.value);
             var yStr = y + "%";
             var line = document.createElementNS(Avionics.SVG.NS, "line");
-            line.setAttribute("x1", x1 + "%");
-            line.setAttribute("x2", x2 + "%");
-            line.setAttribute("y1", yStr);
-            line.setAttribute("y2", yStr);
-            line.setAttribute("class", _lineDef.classStr);
+
+            SaltyUtils.setAttributes(line,
+                ['x1', x1 + '%'],
+                ['x2', x2 + '%'],
+                ['y1', yStr],
+                ['y2', yStr],
+                ['class', _lineDef.classStr]
+                );
+
             if (_lineDef.getValue != null) {
                 this.dynamicLines.push(new GaugeDynamicLine(line, _lineDef.getValue));
             }

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_EICASGauge.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_EICASGauge.js
@@ -128,13 +128,14 @@ var B747_8_EICAS_Common;
         createRect(_x, _y, _width, _height, _class) {
             var rect = document.createElementNS(Avionics.SVG.NS, "rect");
 
-            SaltyUtils.setAttributes(rect, 
-                ['x', _x],
-                ['y', _y],
-                ['width', _width],
-                ['height', _class],
-                ['class', _class]
-                );
+            SaltyUtils.setAttributes(rect,
+                {
+                    'x': _x,
+                    'y': _y,
+                    'width': _width,
+                    'height': _height,
+                    'class': _class
+                });
 
             rect.style.strokeWidth = "2px";
             return rect;
@@ -147,12 +148,13 @@ var B747_8_EICAS_Common;
             var line = document.createElementNS(Avionics.SVG.NS, "line");
 
             SaltyUtils.setAttributes(line,
-                ['x1', x1 + '%'],
-                ['x2', x2 + '%'],
-                ['y1', yStr],
-                ['y2', yStr],
-                ['class', _lineDef.classStr]
-                );
+                {
+                    'x1': x1 + '%',
+                    'x2': x2 + '%',
+                    'y1': yStr,
+                    'y2': yStr,
+                    'class': _lineDef.classStr
+                });
 
             if (_lineDef.getValue != null) {
                 this.dynamicLines.push(new GaugeDynamicLine(line, _lineDef.getValue));

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_EICASGauge.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_EICASGauge.js
@@ -127,11 +127,15 @@ var B747_8_EICAS_Common;
         }
         createRect(_x, _y, _width, _height, _class) {
             var rect = document.createElementNS(Avionics.SVG.NS, "rect");
-            rect.setAttribute("x", _x);
-            rect.setAttribute("y", _y);
-            rect.setAttribute("width", _width);
-            rect.setAttribute("height", _height);
-            rect.setAttribute("class", _class);
+            
+            SaltyUtils.setAttributes(rect, 
+                ['x', _x],
+                ['y', _y],
+                ['width', _width],
+                ['height', _class],
+                ['class', _class]
+                );
+
             rect.style.strokeWidth = "2px";
             return rect;
         }


### PR DESCRIPTION
Added a helper function SaltyUtils.setAttributes(), which should greatly improve readability (2 examples provided in PR). Tested working. If you ok this PR I will use the helper function to replace the large 'setAttribute' blocks in the code whenever I see them.