### PR TITLE
Fix ATIS api call.

### DIFF
--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/COMM/B747_8_FMC_COMM_RequestAtis.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/COMM/B747_8_FMC_COMM_RequestAtis.js
@@ -45,17 +45,9 @@ class FMC_COMM_RequestAtis {
         /* RSK4 */
         fmc.onRightInput[3] = () => {
             let icaos = [];
+            /* get departure airport */
             if (store.arpt1 != "") {
                 icaos.push(store.arpt1);
-            }
-            if (store.arpt2 != "") {
-                icaos.push(store.arpt2);
-            }
-            if (store.arpt3 != "") {
-                icaos.push(store.arpt3);
-            }
-            if (store.arpt4 != "") {
-                icaos.push(store.arpt4);
             }
             const lines = [];
             const newMessage = { "id": Date.now(), "time": '00:00', "opened": null, "type": 'D-ATIS', "content": lines, };
@@ -90,17 +82,9 @@ class FMC_COMM_RequestAtis {
         /* RSK5 */
         fmc.onRightInput[4] = () => {
             let icaos = [];
-            if (store.arpt1 != "") {
-                icaos.push(store.arpt1);
-            }
+            /* get arrival airport */
             if (store.arpt2 != "") {
                 icaos.push(store.arpt2);
-            }
-            if (store.arpt3 != "") {
-                icaos.push(store.arpt3);
-            }
-            if (store.arpt4 != "") {
-                icaos.push(store.arpt4);
             }
             const lines = [];
             const newMessage = { "id": Date.now(), "time": '00:00', "opened": null, "type": 'D-ATIS', "content": lines, };


### PR DESCRIPTION
Updates to the API calls to send the correct stuff for the ATIS call to FBW API.   The old code was trying to send both the origin/destination ICAO codes in the API. Which is invalid.   Since you have separate requests for them.  I update the code to only send the ICAO code for the request.   Now you can get the ATIS back, if it supports it.  Which looks like only the FAA works for me with US ICAO codes, that's not a bug in Salty but rather FBW source for the data..