### PR TITLE
Cockpit Decals

### DIFF
--- a/salty-747/SimObjects/Airplanes/Asobo_B747_8i/TEXTURE/B747_COCKPIT_TEXTS_ALBD.TIF.DDS.json
+++ b/salty-747/SimObjects/Airplanes/Asobo_B747_8i/TEXTURE/B747_COCKPIT_TEXTS_ALBD.TIF.DDS.json
@@ -1,0 +1,1 @@
+{"Version":2,"SourceFileDate":132578746390000000,"Flags":["FL_BITMAP_COMPRESSION","FL_BITMAP_MIPMAP"],"HasTransp":true}


### PR DESCRIPTION
New Cockpit decals for all panels using Futura font.
Also added some missing misc details (PPG logo on Windshield, filled in compass swing card).

OVERHEAD PANEL
![image](https://user-images.githubusercontent.com/71572892/121409297-3bf33900-c959-11eb-82ca-43fd27d1198e.png)

FORWARD PANEL / MCP
![image](https://user-images.githubusercontent.com/71572892/121409726-b623bd80-c959-11eb-8e10-23d02fca9c92.png)

CDUs
![image](https://user-images.githubusercontent.com/71572892/121410080-1d417200-c95a-11eb-9264-1a53a5d65a6d.png)

WINDSHIELD
![image](https://user-images.githubusercontent.com/71572892/121409435-6c3ad780-c959-11eb-8b1b-0450f9d0abf1.png)

