### PR TITLE
Added Seatbelts Memo

### DIFF
--- a/salty-747/SimObjects/Airplanes/Asobo_B747_8i/panel/panel.xml
+++ b/salty-747/SimObjects/Airplanes/Asobo_B747_8i/panel/panel.xml
@@ -646,6 +646,29 @@
 			</Equal>
 		  </Condition>
 		</Annunciation>
+
+		<Annunciation>
+		  <Type>Memo</Type>
+		  <Text>SEATBELTS</Text>
+		  <Condition Suffix=" ON">
+		    <Equal>
+			  <Simvar name="CABIN SEATBELTS ALERT SWITCH" unit="bool"/>
+			  <Constant>1</Constant>
+			</Equal>
+		  </Condition>
+		  <Condition Suffix=" OFF">
+		  	<And>
+		    	<Equal>
+			  		<Simvar name="CABIN SEATBELTS ALERT SWITCH" unit="bool"/>
+			  		<Constant>0</Constant>
+				</Equal>
+				<Equal>
+			  		<Simvar name="SIM ON GROUND" unit="bool"/>
+			  		<Constant>0</Constant>
+				</Equal>
+			</And>
+		  </Condition>
+		</Annunciation>
 		
  
 	<!-- Voices Alerts -->


### PR DESCRIPTION
Added Seatbelts Memo.

As per FCOM:
SEATBELTS ON displays when switch manually selected on.

SEATBELTS OFF when switch selected off and not on the ground.

![image](https://user-images.githubusercontent.com/71572892/129420904-fca60083-ae45-45d7-ae84-af60f8991e16.png)
