### PR TITLE
Some VNAV fixes

### DIFF
--- a/salty-747/html_ui/Pages/Salty/WT/Autopilot/SaltyNavModeSelector.js
+++ b/salty-747/html_ui/Pages/Salty/WT/Autopilot/SaltyNavModeSelector.js
@@ -1578,6 +1578,7 @@
       slot = 2;
      }
      this.currentAutoThrottleStatus = AutoThrottleModeState.SPD;
+     SimVar.SetSimVarValue("K:AP_N1_HOLD", "bool", 0);
      SimVar.SetSimVarValue("L:AP_SPD_ACTIVE", "number", 1);
      if (Simplane.getAutoPilotMachModeActive()) {
        let currentMach = Simplane.getAutoPilotMachHoldValue();

--- a/salty-747/html_ui/Pages/Salty/WT/Autopilot/WT_BaseVnav.js
+++ b/salty-747/html_ui/Pages/Salty/WT/Autopilot/WT_BaseVnav.js
@@ -794,37 +794,23 @@ class WT_BaseVnav {
             || this._fmc._currentVerticalAutopilot._glidepathStatus == GlidepathStatus.GP_ACTIVE || this._fmc._currentVerticalAutopilot._glideslopeStatus == GlideslopeStatus.GS_ACTIVE)) {
             todExists = false;
         }
-        else if (currentSegment !== undefined && currentSegment > 0 && this._verticalFlightPlanSegments[currentSegment].fpa == 0) {
-            todDistanceInFP = this.allWaypoints[this._verticalFlightPlanSegments[currentSegment].targetIndex].cumulativeDistanceInFP + this._verticalFlightPlanSegments[currentSegment].distanceToNextTod;
-            todExists = true;
-        }
-        else if (this._firstPathSegment >= 0 && this.flightplan.activeWaypointIndex <= this._lastClimbIndex) {
-            altitude = this._fmc.cruiseFlightLevel * 100;
-            fpta = this._verticalFlightPlan[this._verticalFlightPlanSegments[this._firstPathSegment].targetIndex].waypointFPTA;
-            fpa = this._verticalFlightPlanSegments[this._firstPathSegment].fpa;
-            if (this.indicatedAltitude > fpta + 100) {
-                altitude = this.indicatedAltitude;
-            }
-            const descentDistance = AutopilotMath.calculateDescentDistance(fpa, altitude - fpta);
-            todDistanceInFP = this.allWaypoints[this._verticalFlightPlanSegments[this._firstPathSegment].targetIndex].cumulativeDistanceInFP - descentDistance;
-            todExists = true;
-        }
         else if (this._firstPathSegment < 0 || !this._verticalFlightPlan[this.flightplan.activeWaypointIndex]) {
             todExists = false;
         }
-        else if (this.flightplan.activeWaypointIndex > this._lastClimbIndex) {
-            altitude = this.indicatedAltitude;
-            if (currentSegment >= 0) {
-                const fptaIdx = this._verticalFlightPlan.findIndex(x => (x.waypointFPTA !== undefined && !x.isClimb && x.waypointFPTA < altitude + 100 && x.indexInFlightPlan >= this.flightplan.activeWaypointIndex));
-                if (fptaIdx > -1) {
-                    const fptaSegment = this._verticalFlightPlan[fptaIdx].segment;
-                    if (fptaSegment !== undefined) {
-                        fpta = this._verticalFlightPlan[this._verticalFlightPlanSegments[fptaSegment].targetIndex].waypointFPTA;
-                        fpa = this._verticalFlightPlanSegments[fptaSegment].fpa;
-                        const descentDistance = AutopilotMath.calculateDescentDistance(fpa, altitude - fpta);
-                        todDistanceInFP = this.allWaypoints[this._verticalFlightPlanSegments[fptaSegment].targetIndex].cumulativeDistanceInFP - descentDistance;
-                        todExists = true;
-                    }
+        altitude = SimVar.GetSimVarValue("L:AIRLINER_CRUISE_ALTITUDE", "number");
+        if (currentSegment >= 0) {
+            const fptaIdx = this._verticalFlightPlan.findIndex(x => (x.waypointFPTA !== undefined && !x.isClimb && x.waypointFPTA < altitude + 100 && x.indexInFlightPlan >= this.flightplan.activeWaypointIndex));
+            if (fptaIdx > -1) {
+                const fptaSegment = this._verticalFlightPlan[fptaIdx].segment;
+                if (fptaSegment !== undefined) {
+                    fpta = this._verticalFlightPlan[this._verticalFlightPlanSegments[fptaSegment].targetIndex].waypointFPTA;
+                    fpa = this._verticalFlightPlanSegments[fptaSegment].fpa;
+                    const descentDistance = AutopilotMath.calculateDescentDistance(fpa, altitude - fpta);
+                    todDistanceInFP = this.allWaypoints[this._verticalFlightPlanSegments[fptaSegment].targetIndex].cumulativeDistanceInFP - descentDistance;
+                    console.log("TARGET ALT:" + fpta.toFixed(0));
+                    console.log("DESCENT DIST:" + descentDistance.toFixed(0));
+                    console.log("TOD DISTANCE:" + todDistanceInFP.toFixed(0));
+                    todExists = true;
                 }
             }
         }

--- a/salty-747/html_ui/Pages/Salty/WT/Autopilot/WT_BaseVnav.js
+++ b/salty-747/html_ui/Pages/Salty/WT/Autopilot/WT_BaseVnav.js
@@ -807,9 +807,6 @@ class WT_BaseVnav {
                     fpa = this._verticalFlightPlanSegments[fptaSegment].fpa;
                     const descentDistance = AutopilotMath.calculateDescentDistance(fpa, altitude - fpta);
                     todDistanceInFP = this.allWaypoints[this._verticalFlightPlanSegments[fptaSegment].targetIndex].cumulativeDistanceInFP - descentDistance;
-                    console.log("TARGET ALT:" + fpta.toFixed(0));
-                    console.log("DESCENT DIST:" + descentDistance.toFixed(0));
-                    console.log("TOD DISTANCE:" + todDistanceInFP.toFixed(0));
                     todExists = true;
                 }
             }

--- a/salty-747/html_ui/Pages/Salty/WT/Autopilot/WT_VnavAutopilot.js
+++ b/salty-747/html_ui/Pages/Salty/WT/Autopilot/WT_VnavAutopilot.js
@@ -530,12 +530,12 @@ class WT_VerticalAutopilot {
     canPathActivate(alreadyActive = false) {
         if (!alreadyActive) {
             //const gsBasedDeviation = -1 * (((this.groundSpeed && this.groundSpeed > 100 ? this.groundSpeed : 200) * (4 / 11)) + (750/11));
-            if (this.path.fpa != 0 && this.path.deviation < 150 && this.path.deviation > -150) {
+            if (this.path.fpa != 0 && this.path.deviation < 250 && this.path.deviation > -250) {
                 return true;
             }
             return false;
         } else {
-            if (this.path.fpa != 0 && this.path.deviation < 150 && this.path.deviation > -150) {
+            if (this.path.fpa != 0 && this.path.deviation < 250 && this.path.deviation > -250) {
                 return true;
             }
             return false;

--- a/salty-747/html_ui/Pages/Salty/WT/Autopilot/WT_VnavAutopilot.js
+++ b/salty-747/html_ui/Pages/Salty/WT/Autopilot/WT_VnavAutopilot.js
@@ -310,6 +310,7 @@ class WT_VerticalAutopilot {
                     console.log("path activate");
                     this._vnavPathStatus = VnavPathStatus.PATH_ACTIVE;
                     this.verticalMode = VerticalNavModeState.PATH;
+                    this._navModeSelector.activateSpeedMode();
                     this._pathInterceptStatus = PathInterceptStatus.NONE;
                     if (this._glidepathStatus === GlidepathStatus.GP_ACTIVE) {
                         this._glidepathStatus = GlidepathStatus.NONE;
@@ -530,12 +531,12 @@ class WT_VerticalAutopilot {
     canPathActivate(alreadyActive = false) {
         if (!alreadyActive) {
             //const gsBasedDeviation = -1 * (((this.groundSpeed && this.groundSpeed > 100 ? this.groundSpeed : 200) * (4 / 11)) + (750/11));
-            if (this.path.fpa != 0 && this.path.deviation < 250 && this.path.deviation > -250) {
+            if (this.path.fpa != 0 && this.path.deviation < 350 && this.path.deviation > -350) {
                 return true;
             }
             return false;
         } else {
-            if (this.path.fpa != 0 && this.path.deviation < 250 && this.path.deviation > -250) {
+            if (this.path.fpa != 0 && this.path.deviation < 350 && this.path.deviation > -350) {
                 return true;
             }
             return false;

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_LegsPage.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_LegsPage.js
@@ -257,9 +257,9 @@ class B747_8_FMC_LegsPage {
 
     bindInputs() {
         for (let i = 0; i < this._wayPointsToRender.length; i++) {
-
             const offsetRender = Math.floor((this._currentPage - 1) * 5);
             const wptRender = this._wayPointsToRender[i + offsetRender];
+            
             // if its a real fix
             if (wptRender && (wptRender.fix.ident !== "$EMPTY" || wptRender.fix.ident !== "$DISCO")) {
                 this._fmc.onRightInput[i] = () => {
@@ -608,18 +608,6 @@ class B747_8_FMC_LegsPage {
                 this.update(true);
             }
         };
-        if (this._currentPage == 1) {
-            this._fmc.onRightInput[0] = () => {
-                const currentInhibit = this._fmc._lnav.sequencingMode === FlightPlanSequencing.INHIBIT;
-                if (currentInhibit) {
-                    this._fmc._lnav.setAutoSequencing();
-                } else {
-                    this._fmc._lnav.setInhibitSequencing();
-                }
-
-                this.resetAfterOp();
-            };
-        }
 
         // EXEC
         this._fmc.onExecPage = () => {
@@ -629,7 +617,6 @@ class B747_8_FMC_LegsPage {
                     this.resetAfterOp();
                 }; // TODO this seems annoying, but this is how stuff works in cj4_fmc right now
                 this._fmc.onExecDefault();
-                console.log("A")
             } else if (this._fmc.fpHasChanged) {
                 this._fmc.fpHasChanged = false;
                 this._fmc.activateRoute(() => {
@@ -638,7 +625,6 @@ class B747_8_FMC_LegsPage {
                         this.resetAfterOp();
                     }; // TODO this seems annoying, but this is how stuff works in cj4_fmc right now
                     this._fmc.onExecDefault();
-                    console.log("B")
                 });
             }
         };

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
@@ -647,7 +647,7 @@ class B747_8_FMC_MainDisplay extends Boeing_FMC {
             }
             return speed = 240;
         }
-        if (desMode == 2) {
+        else if (desMode == 2) {
             speed = SimVar.GetSimVarValue("L:SALTY_DES_SPEED", "knots");
             if (machMode && !isSpeedIntervention) {
                 this.managedMachOff();
@@ -657,16 +657,14 @@ class B747_8_FMC_MainDisplay extends Boeing_FMC {
             let mach = SimVar.GetSimVarValue("L:SALTY_ECON_DES_MACH", "mach");
             speed = SimVar.GetGameVarValue("FROM MACH TO KIAS", "knots", mach);
         }
-        if (desMode == 0) {
+        else if (desMode == 0) {
             if (speed < machlimit && machMode && !isSpeedIntervention) {
                 this.managedMachOff();
             }
             else if (speed >= machlimit && !machMode && !isSpeedIntervention) {
                 this.managedMachOn();
+
             }
-        }
-        if (machMode && !isSpeedIntervention) {
-            this.managedMachOff();
         }
         return speed;
     }

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_VNAVPage.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_VNAVPage.js
@@ -501,7 +501,6 @@ class B747_8_FMC_VNAVPage {
                     value = parseFloat(value);
                     SimVar.SetSimVarValue("L:SALTY_DES_SPEED", "knots", value);
                     SimVar.SetSimVarValue("L:SALTY_VNAV_DES_MODE" , "Enum", 2);
-                    fmc.managedMachOff();
                 }
                 else {
                     fmc.showErrorMessage("INVALID ENTRY");


### PR DESCRIPTION
Changed TOD calc logic, now should show in the proper location when arrival constraints are present.

Changed path to activate within a 350 foot window to give a smoother intercept, avoids getting high on path right at TOD. (was 150 previously)

Fixed auto-throttles sometimes holding constant N1 from TOD onward, causing overspeed in descent.

Fixed not being able to enter a constraint on the active leg on the legs page.

Fixed Mach/IAS cycling bug on descent.