### PR TITLE
Fix Attitude indicator bank

### DIFF
--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/AttitudeIndicator.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/PFD/AttitudeIndicator.js
@@ -437,6 +437,8 @@ class Jet_PFD_AttitudeIndicator extends HTMLElement {
                 break;
             case "bank":
                 this.bankAngle = parseFloat(newValue);
+                const correctionFactor = 0.833;
+                this.bankAngle = this.bankAngle * correctionFactor;
                 break;
             case "slip_skid":
                 this.slipSkidValue = parseFloat(newValue);


### PR DESCRIPTION
Weirdly the default attitude indicator always had an error in displaying roll.

A correction factor has been applied to fix this.

![image](https://user-images.githubusercontent.com/71572892/134564298-79975bd9-10af-4e1e-96da-ce6c6e852bce.png)
