### PR TITLE
fix(ap): AT and VNAV fixes

### DIFF
--- a/salty-747/html_ui/Pages/Salty/WT/Autopilot/SaltyNavModeSelector.js
+++ b/salty-747/html_ui/Pages/Salty/WT/Autopilot/SaltyNavModeSelector.js
@@ -738,6 +738,9 @@
         this.isVNAVOn = !this.isVNAVOn;
       }
       else {
+        if (this.isVNAVOn){
+          return;
+        }
         this.isVNAVOn = true;
         SimVar.SetSimVarValue("K:SPEED_SLOT_INDEX_SET", "number", 2);
       }
@@ -1627,6 +1630,7 @@
 
    activateThrustRefMode() {
      this.currentAutoThrottleStatus = AutoThrottleModeState.THRREF;
+     Coherent.call("GENERAL_ENG_THROTTLE_MANAGED_MODE_SET", ThrottleMode.CLIMB);
      SimVar.SetSimVarValue("K:AP_N1_REF_SET", "number", 90);
      SimVar.SetSimVarValue("K:AP_N1_HOLD", "bool", 1);
    }

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_MainDisplay.js
@@ -987,6 +987,7 @@ class B747_8_FMC_MainDisplay extends Boeing_FMC {
                 if (altitude > 400) {
                     this._pendingVNAVActivation = false;
                     SimVar.SetSimVarValue("L:WT_CJ4_VNAV_ON", "bool", 1);
+                    SimVar.SetSimVarValue("K:AUTO_THROTTLE_TO_GA", "number", 0);
                     this._navModeSelector.onNavChangedEvent('VNAV_PRESSED');
                 }
             }


### PR DESCRIPTION
Fixes throttle levers being able to be moved after transition from HOLD to THR REF on takeoff.

VNAV button now correctly does nothing if pushed when airborne with VNAV already engaged.