### PR TITLE
Updated Fuel Flow

### DIFF
--- a/salty-747/SimObjects/Airplanes/Asobo_B747_8i/engines.cfg
+++ b/salty-747/SimObjects/Airplanes/Asobo_B747_8i/engines.cfg
@@ -4,7 +4,7 @@ minor = 0
 
 [GENERALENGINEDATA]
 engine_type = 1 ; 0=Piston, 1=Jet, 2=None, 3=Helo-Turbine, 4=Rocket, 5=Turboprop
-fuel_flow_scalar = 1.276 ; Fuel flow scalar
+fuel_flow_scalar = 1.44 ; Fuel flow scalar
 min_throttle_limit = -0.25 ; Minimum percent throttle.  Generally negative for turbine reverser
 master_ignition_switch = 0
 starter_type = 2 ; 0=Electric, 1=Manual, 2=Bleed Air


### PR DESCRIPTION
Updated increased fuel flow to further match fuel consumption on long haul flights. Previous calculation has become inaccurate landing with in excess of 60,000+ lbs on long haul flights.

Short haul flights will have slightly more planned fuel burn, with long haul flights having slightly less planned fuel burn due to linear fuel burn from Asobo.