### PR TITLE
fix(AP): Fixes some AP bugs

### DIFF
--- a/salty-747/html_ui/Pages/Salty/WT/Autopilot/SaltyNavModeSelector.js
+++ b/salty-747/html_ui/Pages/Salty/WT/Autopilot/SaltyNavModeSelector.js
@@ -557,20 +557,23 @@
   * Determines speed that FLCH should engage with when pushed.
   */
    getFLCHSpeed() {
+    const fmcSpeed = SimVar.GetSimVarValue("AUTOPILOT AIRSPEED HOLD VAR:2", "knots");
+    const mcpSpeed = SimVar.GetSimVarValue("AUTOPILOT AIRSPEED HOLD VAR:1", "knots");
+    const speed = Simplane.getIndicatedSpeed();
      if (this.isVNAVOn) {
-      const fmcSpeed = SimVar.GetSimVarValue("AUTOPILOT AIRSPEED HOLD VAR:2", "knots");
        if (SimVar.GetSimVarValue("L:AP_SPEED_INTERVENTION_ACTIVE", "number")) {
-        const mcpSpeed = SimVar.GetSimVarValue("AUTOPILOT AIRSPEED HOLD VAR:1", "knots");
         Coherent.call("AP_SPD_VAR_SET", 1, mcpSpeed);
        }
        else if (isFinite(fmcSpeed)) {
         Coherent.call("AP_SPD_VAR_SET", 1, fmcSpeed);
        }
        else {
-         const speed = Simplane.getIndicatedSpeed();
-         Coherent.call("AP_SPD_VAR_SET", 1, speed);
-       }
+        Coherent.call("AP_SPD_VAR_SET", 1, speed);
+      }
      }
+     else {
+      Coherent.call("AP_SPD_VAR_SET", 1, speed);
+    }
    }
 
  /**
@@ -749,9 +752,20 @@
         this.isVNAVOn = true;
         SimVar.SetSimVarValue("K:SPEED_SLOT_INDEX_SET", "number", 2);
       }
+      SimVar.SetSimVarValue("L:AP_SPEED_INTERVENTION_ACTIVE", "number", 0);
       SimVar.SetSimVarValue("L:WT_CJ4_VNAV_ON", "number", this.isVNAVOn ? 1 : 0);
       SimVar.SetSimVarValue("L:AP_VNAV_ACTIVE", "number", this.isVNAVOn ? 1 : 0);
       SimVar.SetSimVarValue("L:AP_VNAV_ARMED", "number", this.isVNAVOn ? 1 : 0);
+      
+      if (SimVar.GetSimVarValue("L:SALTY_VNAV_CLB_MODE", "number") == 1) {
+        SimVar.SetSimVarValue("L:SALTY_VNAV_CLB_MODE", "number", 0);
+      }
+      if (SimVar.GetSimVarValue("L:SALTY_VNAV_CRZ_MODE", "number") == 1) {
+        SimVar.SetSimVarValue("L:SALTY_VNAV_CRZ_MODE", "number", 0);
+      }
+      if (SimVar.GetSimVarValue("L:SALTY_VNAV_DES_MODE", "number") == 1) {
+        SimVar.SetSimVarValue("L:SALTY_VNAV_DES_MODE", "number", 0);
+      }
 
       if (this.currentVerticalActiveState === VerticalNavModeState.ALTCAP || this.currentVerticalActiveState === VerticalNavModeState.ALTS
         || this.currentVerticalActiveState === VerticalNavModeState.ALTSCAP || this.currentVerticalActiveState === VerticalNavModeState.ALTV

--- a/salty-747/html_ui/Pages/Salty/WT/Autopilot/SaltyNavModeSelector.js
+++ b/salty-747/html_ui/Pages/Salty/WT/Autopilot/SaltyNavModeSelector.js
@@ -558,9 +558,13 @@
   */
    getFLCHSpeed() {
      if (this.isVNAVOn) {
-       const fmcSpeed = SimVar.GetSimVarValue("AUTOPILOT AIRSPEED HOLD VAR:2", "knots");
-       if (isFinite(fmcSpeed)) {
-         Coherent.call("AP_SPD_VAR_SET", 1, fmcSpeed);
+      const fmcSpeed = SimVar.GetSimVarValue("AUTOPILOT AIRSPEED HOLD VAR:2", "knots");
+       if (SimVar.GetSimVarValue("L:AP_SPEED_INTERVENTION_ACTIVE", "number")) {
+        const mcpSpeed = SimVar.GetSimVarValue("AUTOPILOT AIRSPEED HOLD VAR:1", "knots");
+        Coherent.call("AP_SPD_VAR_SET", 1, mcpSpeed);
+       }
+       else if (isFinite(fmcSpeed)) {
+        Coherent.call("AP_SPD_VAR_SET", 1, fmcSpeed);
        }
        else {
          const speed = Simplane.getIndicatedSpeed();
@@ -577,6 +581,7 @@
      SimVar.SetSimVarValue("L:WT_CJ4_VNAV_ON", "number", 0);
      SimVar.SetSimVarValue("L:AP_VNAV_ACTIVE", "number", 0);
      SimVar.SetSimVarValue("L:AP_VNAV_ARMED", "number", 0);
+     SimVar.SetSimVarValue("L:AP_SPEED_INTERVENTION_ACTIVE", "number", 0);
    }
 
  /**

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
@@ -259,7 +259,7 @@ class Boeing_FMC extends FMCMainDisplay {
         return this._isSPDActive;
     }
     getIsSpeedInterventionActive() {
-        return this._isSpeedInterventionActive;
+        return SimVar.GetSimVarValue("L:AP_SPEED_INTERVENTION_ACTIVE", "boolean");
     }
     toggleSpeedIntervention() {
         if (this.getIsSpeedInterventionActive()) {


### PR DESCRIPTION
- FLCH now uses VNAV MCP SPD as initial target if selected while VNAV active and in speed intervention mode.
- FLCH now defaults to current IAS as initial target speed if no valid FMC speed available.
- Fixed bug requiring MCP speed knob to be pushed twice to open in some instances.
- Fixed bug causing VNAV CDU page to erroneously display MCP SPD mode in some instances.