### PR TITLE
fix: lower EICAS fuel to match upper EICAS fuel unit

### DIFF
--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Fuel.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Fuel.js
@@ -7,6 +7,7 @@ var B747_8_LowerEICAS_Fuel;
             this.allFuelComponents = new Array();
             this.gallonToMegagrams = 0;
             this.gallonToMegapounds = 0;
+            this.units;
             this.isInitialised = false;
         }
         get templateID() { return "B747_8LowerEICASFuelTemplate"; }
@@ -136,6 +137,20 @@ var B747_8_LowerEICAS_Fuel;
             }
         }
         update(_deltaTime) {
+            const storedUnits = SaltyDataStore.get("OPTIONS_UNITS", "KG");
+            switch (storedUnits) {
+                case "KG":
+                    this.units = true;
+                    break;
+                case "LBS":
+                    this.units = false;
+                    break;
+                default:
+                    this.units = true;
+            }
+            if (!this.isInitialised) {
+                return;
+            }
             if (!this.isInitialised) {
                 return;
             }
@@ -154,7 +169,7 @@ var B747_8_LowerEICAS_Fuel;
                 }
             }
             if (this.unitTextSVG) {
-                if (SimVar.GetSimVarValue("L:SALTY_UNIT_IS_METRIC", "bool")) {
+                if (this.units) {
                     this.unitTextSVG.textContent = "KGS X 1000";
                 }
                 else {
@@ -192,14 +207,14 @@ var B747_8_LowerEICAS_Fuel;
         }
         getTotalFuelInMegagrams() {
             let factor = this.gallonToMegapounds;
-            if (SimVar.GetSimVarValue("L:SALTY_UNIT_IS_METRIC", "bool")) {
+            if (this.units) {
                 factor = this.gallonToMegagrams;
             }
             return (SimVar.GetSimVarValue("FUEL TOTAL QUANTITY", "gallons") * factor);
         }
         getMainTankFuelInMegagrams(_index) {
             let factor = this.gallonToMegapounds;
-            if (SimVar.GetSimVarValue("L:SALTY_UNIT_IS_METRIC", "bool")) {
+            if (this.units) {
                 factor = this.gallonToMegagrams;
             }
             return (SimVar.GetSimVarValue("FUELSYSTEM TANK QUANTITY:" + _index, "gallons") * factor);

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Fuel.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_LowerEICAS_Fuel.js
@@ -7,7 +7,7 @@ var B747_8_LowerEICAS_Fuel;
             this.allFuelComponents = new Array();
             this.gallonToMegagrams = 0;
             this.gallonToMegapounds = 0;
-            this.units;
+            this.units = true;
             this.isInitialised = false;
         }
         get templateID() { return "B747_8LowerEICASFuelTemplate"; }
@@ -147,9 +147,6 @@ var B747_8_LowerEICAS_Fuel;
                     break;
                 default:
                     this.units = true;
-            }
-            if (!this.isInitialised) {
-                return;
             }
             if (!this.isInitialised) {
                 return;


### PR DESCRIPTION
Fuel unit on upper EICAS uses settings from SatlyDataStore, but Lower EICAS uses the value from SimVar. Both EICAS now have the same unit displayed on startup.