### PR TITLE
fix grossWeight unit

### DIFF
--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_TakeOffPage.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_TakeOffPage.js
@@ -121,7 +121,7 @@ class FMCTakeOffPage {
         }
         let taxiBurn = 2;
         let grossWeight;
-        if (SimVar.GetSimVarValue("L:SALTY_UNIT_IS_METRIC", "bool")) {
+        if (SaltyDataStore.get("OPTIONS_UNITS", "KG")) {
             grossWeight = fmc.getWeight(false);
         }
         else {


### PR DESCRIPTION
Gross weight on fmc take-off page should based on SaltyDataStore not from SimVar