### PR TITLE
fix(ILS): Fixes ILS failing to autotune in some instances.

### DIFF
--- a/salty-747/html_ui/Pages/Salty/WT/Autopilot/NavToNavTransfer.js
+++ b/salty-747/html_ui/Pages/Salty/WT/Autopilot/NavToNavTransfer.js
@@ -72,11 +72,11 @@ class NavToNavTransfer {
 
   handleTunePending() {
     const timeStamp = Date.now();
-    if (timeStamp - this.termTimestamp > 30000 || this.navRadioSystem.radioStates[1].mode === NavRadioMode.Auto) {
+    if (timeStamp - this.termTimestamp > 30000 || this.navRadioSystem.radioStates[3].mode === NavRadioMode.Auto) {
       const frequency = this.fpm.getApproachNavFrequency();
 
       if (isFinite(frequency) && frequency >= 108 && frequency <= 117.95) {
-        this.navRadioSystem.radioStates[1].setManualFrequency(frequency);
+        this.navRadioSystem.radioStates[3].setManualFrequency(frequency);
         this.transferState = NavToNavTransfer.ARMED;
       }
       else {
@@ -86,7 +86,7 @@ class NavToNavTransfer {
   }
 
   handleTuneFailed() {
-    const hasLoc = SimVar.GetSimVarValue('NAV HAS LOCALIZER:1', 'number');
+    const hasLoc = SimVar.GetSimVarValue('NAV HAS LOCALIZER:3', 'number');
     const frequency = this.fpm.getApproachNavFrequency();
 
     if (isNaN(frequency)) {
@@ -108,7 +108,7 @@ class NavToNavTransfer {
   handleArmed() {
     const frequency = this.fpm.getApproachNavFrequency();
     if (isNaN(frequency)) {
-      const hasLoc = SimVar.GetSimVarValue('NAV HAS LOCALIZER:1', 'number') !== 0;
+      const hasLoc = SimVar.GetSimVarValue('NAV HAS LOCALIZER:3', 'number') !== 0;
       if (!hasLoc) {
         this.transferState = NavToNavTransfer.TUNE_FAILED;
       }
@@ -138,7 +138,7 @@ class NavToNavTransfer {
    * Attempts to auto-tune the localizer.
    */
   tryTuneLocalizer() {
-    if (this.navRadioSystem.radioStates[1].mode !== NavRadioMode.Auto) {
+    if (this.navRadioSystem.radioStates[3].mode !== NavRadioMode.Auto) {
       this.termTimestamp = Date.now();
     }
 

--- a/salty-747/html_ui/Pages/Salty/WT/Autopilot/SaltyNavModeSelector.js
+++ b/salty-747/html_ui/Pages/Salty/WT/Autopilot/SaltyNavModeSelector.js
@@ -340,6 +340,7 @@
       switch (this.currentLateralActiveState) {
         case LateralNavModeState.ROLL:
           SimVar.SetSimVarValue("L:WT_CJ4_NAV_ON", "number", 1);
+          SimVar.SetSimVarValue("L:AP_LNAV_ACTIVE", "number", 1);
           this.changeToCorrectLNavForMode(true, false);
           break;
         case LateralNavModeState.LNAV:
@@ -348,6 +349,7 @@
         case LateralNavModeState.TO:
         case LateralNavModeState.GA:
           SimVar.SetSimVarValue("L:WT_CJ4_NAV_ON", "number", 1);
+          SimVar.SetSimVarValue("L:AP_LNAV_ACTIVE", "number", 1);
           SimVar.SetSimVarValue("L:WT_CJ4_HDG_ON", "number", 0);
           this.changeToCorrectLNavForMode(false, false);
           SimVar.SetSimVarValue("K:AP_PANEL_HEADING_HOLD", "number", 1);

--- a/salty-747/html_ui/Pages/Salty/WT/Waypoint.js
+++ b/salty-747/html_ui/Pages/Salty/WT/Waypoint.js
@@ -427,7 +427,7 @@ class AirportInfo extends WayPointInfo {
         this.frequencies = [];
         if (data.frequencies) {
             for (let i = 0; i < data.frequencies.length; i++) {
-                this.frequencies.push(new Frequency(data.frequencies[i].name, data.frequencies[i].freqMHz, data.frequencies[i].freqBCD16));
+                this.frequencies.push(new Frequency(data.frequencies[i].name, data.frequencies[i].freqMHz, data.frequencies[i].freqBCD16, data.frequencies[i].type));
             }
         }
         this.runways = [];
@@ -941,10 +941,12 @@ class IntersectionInfo extends WayPointInfo {
 IntersectionInfo.readManager = new InstrumentDataReadManager();
 IntersectionInfo.longestAirway = 0;
 class Frequency {
-    constructor(_name, _mhValue, _bcd16Value) {
+    constructor(_name, _mhValue, _bcd16Value, _type) {
         this.name = _name;
         this.mhValue = _mhValue;
         this.bcd16Value = _bcd16Value;
+        this.bcd16Value = _bcd16Value;
+        this.type = _type;
     }
 }
 

--- a/src/modules/src/fpm/flightplanning/FlightPlanManager.ts
+++ b/src/modules/src/fpm/flightplanning/FlightPlanManager.ts
@@ -154,9 +154,10 @@ export class FlightPlanManager {
   /**
    * Switches the active flight plan index to the supplied index.
    * @param index The index to now use for the active flight plan.
+   * @param thenSetActive Indicates if the flight plan should become the active flightplan. (inop here)
    * @param callback A callback to call when the operation has completed.
    */
-  public setCurrentFlightPlanIndex(index: number, callback = EmptyCallback.Boolean): void {
+  public setCurrentFlightPlanIndex(index: number, thenSetActive = false, callback = EmptyCallback.Boolean): void {
     if (index >= 0 && index < this._flightPlans.length) {
       this._currentFlightPlanIndex = index;
       callback(true);
@@ -839,19 +840,6 @@ export class FlightPlanManager {
   }
 
   /**
-   * Gets the heading of the selected departure runway.
-   */
-  public getDepartureRunwayDirection(): Number {
-    const origin = this.getOrigin();
-    const currentFlightPlan = this._flightPlans[this._currentFlightPlanIndex];
-    if (origin && origin.infos instanceof AirportInfo && currentFlightPlan.procedureDetails.originRunwayIndex !== -1) {
-      const runway = origin.infos.oneWayRunways[currentFlightPlan.procedureDetails.originRunwayIndex];
-      return runway.direction;
-    }
-    return undefined;
-  }
-
-  /**
    * Gets the best runway based on the current plane heading.
    */
   public getDetectedCurrentRunway(): OneWayRunway {
@@ -1059,8 +1047,8 @@ export class FlightPlanManager {
    * Clears a discontinuity from the end of a waypoint.
    * @param index 
    */
-  public clearDiscontinuity(index: number): void {
-    const currentFlightPlan = this._flightPlans[this._currentFlightPlanIndex];
+  public clearDiscontinuity(index: number, fplnIndex = this._currentFlightPlanIndex): void {
+    const currentFlightPlan = this._flightPlans[fplnIndex];
     const waypoint = currentFlightPlan.getWaypoint(index);
 
     if (waypoint !== undefined) {
@@ -1245,10 +1233,10 @@ export class FlightPlanManager {
       const approachRunway = this.getApproach().runway.trim();
 
       const aptInfo = destination.infos as AirportInfo;
-      const frequency = aptInfo.namedFrequencies.find(f => f.name.replace("RW0", "").replace("RW", "").indexOf(approachRunway) !== -1);
+      const frequency = aptInfo.frequencies.find(f => f.name.replace("RW0", "").replace("RW", "").indexOf(approachRunway) !== -1);
 
       if (frequency) {
-        return frequency.value;
+        return Math.round(frequency.freqMHz * 100) / 100;
       }
     }
 
@@ -1549,4 +1537,16 @@ export class FlightPlanManager {
     this._updateFlightPlanVersion();
   }
 
+  /**
+  * Gets the heading of the selected departure runway.
+  */
+  public getDepartureRunwayDirection(): Number {
+    const origin = this.getOrigin();
+    const currentFlightPlan = this._flightPlans[this._currentFlightPlanIndex];
+    if (origin && origin.infos instanceof AirportInfo && currentFlightPlan.procedureDetails.originRunwayIndex !== -1) {
+      const runway = origin.infos.oneWayRunways[currentFlightPlan.procedureDetails.originRunwayIndex];
+      return runway.direction;
+    }
+    return undefined;
+  }
 }

--- a/src/modules/src/fpm/flightplanning/RawDataMapper.ts
+++ b/src/modules/src/fpm/flightplanning/RawDataMapper.ts
@@ -1,7 +1,7 @@
 /** 
  * A class for mapping raw facility data to WayPoints. 
  */
-export class RawDataMapper {
+ export class RawDataMapper {
 
   /**
    * Maps a raw facility record to a WayPoint.
@@ -42,6 +42,8 @@ export class RawDataMapper {
 
         info.oneWayRunways = [];
         facility.runways.forEach(runway => info.oneWayRunways.push(...Object.assign(new Runway(), runway).splitIfTwoWays()));
+
+        info.frequencies = facility.frequencies;
 
         info.oneWayRunways.sort(RawDataMapper.sortRunways);
         waypoint.infos = info;
@@ -143,4 +145,3 @@ export class RawDataMapper {
     return enrouteTransition.legs[enrouteTransition.legs.length - 1].fixIcao.substring(7, 12).trim();
   }
 }
-


### PR DESCRIPTION
Updates some WT files to latest versions which fixes the issue of ILS failing to tune sometimes when selecting approach in CDU. 

Note it is still required to select the approach for now: the AP will not couple to a manually tuned ILS although the indications will now show correctly on PFD.