### PR TITLE
fix(FMC): Fixed POS page 4 & Flightphase sequencing

### DIFF
--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_PosInitPage.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_PosInitPage.js
@@ -45,7 +45,7 @@ class FMCPosInitPage {
         ]);
 
         fmc.onPrevPage = () => {
-            FMCPosInitPage.ShowPage3(fmc);
+            FMCPosInitPage.ShowPage4(fmc);
         };
 
         fmc.onNextPage = () => {
@@ -202,7 +202,7 @@ class FMCPosInitPage {
         if (fmc.initCoordinates) {
             irsPos = fmc.initCoordinates;
         }
-        let irsGs = SimVar.GetSimVarValue("SURFACE RELATIVE GROUND SPEED", "knots") + "KT";
+        let irsGs = SimVar.GetSimVarValue("SURFACE RELATIVE GROUND SPEED", "knots").toFixed(0) + "KT";
         fmc.setTemplate([
             ["POS REF", "4", "4"],
             ["\xa0IRS L", "GS"],

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/FMCMainDisplay.js
@@ -1728,7 +1728,7 @@ class FMCMainDisplay extends BaseAirliners {
                 }
             }
             if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_CLIMB) {
-                let altitude = SimVar.GetSimVarValue("PLANE ALTITUDE", "feet");
+                let altitude = SimVar.GetSimVarValue("INDICATED ALTITUDE", "feet");
                 let cruiseFlightLevel = this.cruiseFlightLevel * 100;
                 if (isFinite(cruiseFlightLevel)) {
                     if (altitude >= 0.98 * cruiseFlightLevel) {
@@ -1738,7 +1738,7 @@ class FMCMainDisplay extends BaseAirliners {
                 }
             }
             if (this.currentFlightPhase === FlightPhase.FLIGHT_PHASE_CRUISE) {
-                let altitude = SimVar.GetSimVarValue("PLANE ALTITUDE", "feet");
+                let altitude = SimVar.GetSimVarValue("INDICATED ALTITUDE", "feet");
                 let cruiseFlightLevel = this.cruiseFlightLevel * 100;
                 if (isFinite(cruiseFlightLevel)) {
                     if (altitude < 0.90 * cruiseFlightLevel && !this._isStepClimbing) {


### PR DESCRIPTION
### POS page 4 & Flightphase sequencing fix .

![image](https://user-images.githubusercontent.com/71572892/159186978-8e1a90eb-00ef-4d34-9ec6-db7969c18361.png)

- Fixes visual bug with groundspeed.

- Fixes a bug where pressing PREV PAGE on page 1/4 took you to page 3/4 instead of 4/4.

- Fixes a bug causing FMC not to change into CRZ or DES modes due to using wrong altimeter source.

**Testing instructions:**

Check FMC POS page 4 looks normal (GS displayed with no decimal places) when in flight. 

Check that cycling through the pages with NEXT PAGE and PREV page works as expected.

Using live weather, set a cruise altitude of FL360 in the FMC. Takeoff and check that CLB changes to CRZ on the upper EICAS mode when levelling off at FL360.

