### PR TITLE
feat(Debug): AP Debug Page

### DIFF
--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/OPTIONS/B747_8_FMC_SaltyOptions.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/OPTIONS/B747_8_FMC_SaltyOptions.js
@@ -17,7 +17,7 @@ class FMCSaltyOptions {
             ["", ""],
             ["<METAR SRC", "ATIS SRC>"],
             ["", ""],
-            ["<TAF SRC", ""],
+            ["<TAF SRC", "DEBUG PAGE>"],
             ["", ""],
             [`<SIMBRIEF`, ""],
             ["", ""],
@@ -44,9 +44,14 @@ class FMCSaltyOptions {
               FMCSaltyOptions_Atis.ShowPage(fmc);
         };
 
-        /* RSK3 */
+        /* LSK3 */
         fmc.onLeftInput[2] = () => {
               FMCSaltyOptions_Taf.ShowPage(fmc);
+        };
+
+        /* LSK3 */
+        fmc.onRightInput[2] = () => {
+            SimVar.SetSimVarValue("H:B747_8_EICAS_2_EICAS_CHANGE_PAGE_info", "bool", 1);
         };
         
         /* LSK4 */


### PR DESCRIPTION
### Autopilot Debug Page

![image](https://user-images.githubusercontent.com/71572892/159194432-7f4f6cf3-8a6c-441d-b8e5-ffab5ddc49b4.png)

Adds an AP debug page on the lower EICAS accessible only through FMC > SALTY > DEBUG PAGE.

Shows current state of internal AP logic (and whatever else might be useful in future), users can submit screenshots to aid in troubleshooting the AP.

**Testing Instructions:
N/A**