### PR TITLE
fix(fmc, eicas): minor bug fixes

### DIFF
--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_UpperEICAS.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/EICAS/Pages/B747_8_UpperEICAS.js
@@ -162,8 +162,8 @@ var B747_8_UpperEICAS;
             else {
                 this.pressureInfo.style.visibility = "visible";
             }
-            this.cabinAlt.textContent = (Math.round(Simplane.getPressurisationCabinAltitude() / 100) * 100).toFixed(0);
-            this.cabinRate.textContent = (Math.round(Simplane.getPressurisationCabinAltitudeRate() / 100) * 100).toFixed(0);
+            this.cabinAlt.textContent = this.allValueComponents.push(new Airliners.DynamicValueComponent(this.querySelector("#CAB_ALT_Value"), Simplane.getPressurisationCabinAltitude));
+            this.cabinRate.textContent = this.allValueComponents.push(new Airliners.DynamicValueComponent(this.querySelector("#RATE_Value"), Simplane.getPressurisationCabinAltitudeRate));
             let deltaPValue = Math.abs(Simplane.getPressurisationDifferential() * 10);
             if (Math.round(deltaPValue) < 10) {
                 this.deltaP.textContent = "0" + deltaPValue.toFixed(0);

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_PosReport.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_PosReport.js
@@ -146,33 +146,7 @@ class FMC_PosReport {
         };
 
         function getUTC(p) {
-            if (p == "ata") {
-                var utc = new Date();
-                if (utc.getUTCHours() <= 9) {
-                    var utcHours = "0" + utc.getUTCHours();
-                } else {
-                    var utcHours = utc.getUTCHours();
-                }
-                if (utc.getUTCMinutes() <= 9) {
-                    var utcMinutes = "0" + utc.getUTCMinutes();
-                } else {
-                    var utcMinutes = utc.getUTCMinutes();
-                }
-                return utcHours.toString() + utcMinutes.toString() + "Z";
-            } else if (p == "eta") {
-                var utc = new Date();
-                if (utc.getUTCHours() <= 9) {
-                    var utcHours = "0" + utc.getUTCHours();
-                } else {
-                    var utcHours = utc.getUTCHours();
-                }
-                if (utc.getUTCMinutes() <= 9) {
-                    var utcMinutes = "0" + utc.getUTCMinutes();
-                } else {
-                    var utcMinutes = utc.getUTCMinutes();
-                }
-                return utcHours.toString() + utcMinutes.toString() + "Z";
-            } else if (p == "dest") {
+            if (p == "ata" || p == "eta" || p == "dest") {
                 var utc = new Date();
                 if (utc.getUTCHours() <= 9) {
                     var utcHours = "0" + utc.getUTCHours();

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_PosReport.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_PosReport.js
@@ -159,7 +159,7 @@ class FMC_PosReport {
                     var utcMinutes = utc.getUTCMinutes();
                 }
                 return utcHours.toString() + utcMinutes.toString() + "Z";
-            } else if (p == "ete") {
+            } else if (p == "eta") {
                 var utc = new Date();
                 if (utc.getUTCHours() <= 9) {
                     var utcHours = "0" + utc.getUTCHours();

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
@@ -26,7 +26,7 @@ class Boeing_FMC extends FMCMainDisplay {
     Init() {
         super.Init();
         this.maxCruiseFL = 450;
-        this.cruiseFlightLevel = 100;
+        this.cruiseFlightLevel = NaN;
         this.onExec = () => {
             if (this.onExecPage) {
                 console.log("if this.onExecPage");


### PR DESCRIPTION
**Changes:**
- The DUCT PRESS section on the Upper EICAS should be more accurate
![image](https://user-images.githubusercontent.com/63889859/159229827-4d6668d3-e6fc-4e30-92bd-922277ea2a52.png)
- The ETA in POS REPORT will no longer show "UNDEFINED"
- INIT PERF CRZ level will be blank squares instead of defaulting to FL100

**Testing instructions:**
- For the DUCT PRESS: press the ENG button and check the DUCT PRESS section on the upper EICAS. Both the CAB ALT and RATE value should increase/decrease dynamically
- For the ETA: Load up a flight plan. At any time, check if ETA says "UNDEFINED" or not
- For the CRZ level: start up the aircraft and check if CRZ section shows 5 black boxes.