### PR TITLE
fix(model): Bank Angle Selector set to AUTO by default

### DIFF
--- a/salty-747/SimObjects/Airplanes/Asobo_B747_8i/Climb.flt
+++ b/salty-747/SimObjects/Airplanes/Asobo_B747_8i/Climb.flt
@@ -272,6 +272,7 @@ AutoThrottleArm=False
 GPSdrivesNAV1=True
 IsUsedForLesson=False
 ForceDisplayUI=False
+MaxBankIndex=6
 
 [Controls.0]
 SpoilersHandle=000.00

--- a/salty-747/SimObjects/Airplanes/Asobo_B747_8i/approach.FLT
+++ b/salty-747/SimObjects/Airplanes/Asobo_B747_8i/approach.FLT
@@ -271,6 +271,7 @@ AutoThrottleArm=False
 GPSdrivesNAV1=True
 IsUsedForLesson=False
 ForceDisplayUI=False
+MaxBankIndex=6
 
 [Controls.0]
 SpoilersHandle=000.00

--- a/salty-747/SimObjects/Airplanes/Asobo_B747_8i/apron.FLT
+++ b/salty-747/SimObjects/Airplanes/Asobo_B747_8i/apron.FLT
@@ -269,6 +269,7 @@ AutoThrottleArm=False
 GPSdrivesNAV1=False
 IsUsedForLesson=False
 ForceDisplayUI=False
+MaxBankIndex=6
 
 [Controls.0]
 SpoilersHandle=000.00

--- a/salty-747/SimObjects/Airplanes/Asobo_B747_8i/cruise.FLT
+++ b/salty-747/SimObjects/Airplanes/Asobo_B747_8i/cruise.FLT
@@ -271,6 +271,7 @@ AutoThrottleArm=False
 GPSdrivesNAV1=True
 IsUsedForLesson=False
 ForceDisplayUI=False
+MaxBankIndex=6
 
 [Controls.0]
 SpoilersHandle=000.00

--- a/salty-747/SimObjects/Airplanes/Asobo_B747_8i/final.FLT
+++ b/salty-747/SimObjects/Airplanes/Asobo_B747_8i/final.FLT
@@ -272,6 +272,7 @@ AutoThrottleArm=False
 GPSdrivesNAV1=True
 IsUsedForLesson=False
 ForceDisplayUI=False
+MaxBankIndex=6
 
 [Controls.0]
 SpoilersHandle=000.00

--- a/salty-747/SimObjects/Airplanes/Asobo_B747_8i/hangar.flt
+++ b/salty-747/SimObjects/Airplanes/Asobo_B747_8i/hangar.flt
@@ -209,6 +209,7 @@ AutoThrottleArm=False
 GPSdrivesNAV1=False
 IsUsedForLesson=False
 ForceDisplayUI=False
+MaxBankIndex=6
 
 [Controls.0]
 SpoilersHandle=000.00

--- a/salty-747/SimObjects/Airplanes/Asobo_B747_8i/taxi.FLT
+++ b/salty-747/SimObjects/Airplanes/Asobo_B747_8i/taxi.FLT
@@ -268,6 +268,7 @@ AutoThrottleArm=False
 GPSdrivesNAV1=True
 IsUsedForLesson=False
 ForceDisplayUI=False
+MaxBankIndex=6
 
 [Controls.0]
 SpoilersHandle=000.00


### PR DESCRIPTION


![159269125-45aa906f-93ce-4dc9-b8fc-88863263a505](https://user-images.githubusercontent.com/61822722/159314474-90dcf53c-ec12-480f-aa6c-8822fe3d5c41.png)

Added MaxBankIndex to other FLT files that were missing the index which was present in the runway.FLT file.

This PR is aimed to improve the LNAV tracking that is achieved by setting the Bank Angle Selector knob to AUTO when starting from a Cold and Dark flight.

Testing Instructions:

1. Start the sim fresh and spawn C&D.
2. Observe that the Bank Angle Selector knob is set to AUTO upon spawning.
