### PR TITLE
fix(fmc): Inhibit VNAV when there is no CRZ ALT + ETA in POS Report fix

### DIFF
--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_PosReport.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_PosReport.js
@@ -2,7 +2,7 @@ class FMC_PosReport {
     static ShowPage(fmc, store = {sendCompany: "<SEND", sendAtc: "SEND>"}) {
         fmc.activeSystem = "FMC";
         fmc.clearDisplay();
-        
+
         let fltNoCell = SimVar.GetSimVarValue("ATC FLIGHT NUMBER", "string") ? SimVar.GetSimVarValue("ATC FLIGHT NUMBER", "string") : "XXXX";
         let currPos = new LatLong(SimVar.GetSimVarValue("GPS POSITION LAT", "degree latitude"), SimVar.GetSimVarValue("GPS POSITION LON", "degree longitude")).toDegreeString();
         let posCell = "---";
@@ -30,7 +30,7 @@ class FMC_PosReport {
         let posFuelCell = fmc.getBlockFuel(true).toFixed(1);
         let companySendCell = "SEND";
         let atcSendCell = "SEND";
-        
+
         let speed = Simplane.getGroundSpeed();
         let currentTime = SimVar.GetGlobalVarValue("LOCAL TIME", "seconds");
         let currentFuel = SimVar.GetSimVarValue("FUEL TOTAL QUANTITY", "gallons") * SimVar.GetSimVarValue("FUEL WEIGHT PER GALLON", "pounds") / 1000;
@@ -146,7 +146,7 @@ class FMC_PosReport {
         };
 
         function getUTC(p) {
-            if (p == "ata" || p == "eta") {
+            if (p == "ata" || p == "ete" || p == "dest") {
                 var utc = new Date();
                 if (utc.getUTCHours() <= 9) {
                     var utcHours = "0" + utc.getUTCHours();

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_PosReport.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/B747_8_FMC_PosReport.js
@@ -146,33 +146,7 @@ class FMC_PosReport {
         };
 
         function getUTC(p) {
-            if (p == "ata") {
-                var utc = new Date();
-                if (utc.getUTCHours() <= 9) {
-                    var utcHours = "0" + utc.getUTCHours();
-                } else {
-                    var utcHours = utc.getUTCHours();
-                }
-                if (utc.getUTCMinutes() <= 9) {
-                    var utcMinutes = "0" + utc.getUTCMinutes();
-                } else {
-                    var utcMinutes = utc.getUTCMinutes();
-                }
-                return utcHours.toString() + utcMinutes.toString() + "Z";
-            } else if (p == "ete") {
-                var utc = new Date();
-                if (utc.getUTCHours() <= 9) {
-                    var utcHours = "0" + utc.getUTCHours();
-                } else {
-                    var utcHours = utc.getUTCHours();
-                }
-                if (utc.getUTCMinutes() <= 9) {
-                    var utcMinutes = "0" + utc.getUTCMinutes();
-                } else {
-                    var utcMinutes = utc.getUTCMinutes();
-                }
-                return utcHours.toString() + utcMinutes.toString() + "Z";
-            } else if (p == "dest") {
+            if (p == "ata" || p == "eta") {
                 var utc = new Date();
                 if (utc.getUTCHours() <= 9) {
                     var utcHours = "0" + utc.getUTCHours();

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
@@ -26,7 +26,7 @@ class Boeing_FMC extends FMCMainDisplay {
     Init() {
         super.Init();
         this.maxCruiseFL = 450;
-        this.cruiseFlightLevel = null;
+        this.cruiseFlightLevel;
         this.onExec = () => {
             if (this.onExecPage) {
                 console.log("if this.onExecPage");
@@ -131,7 +131,7 @@ class Boeing_FMC extends FMCMainDisplay {
             if (SimVar.GetSimVarValue("L:AP_APP_ARMED", "bool") === 0) {
                 SimVar.SetSimVarValue("L:AP_APP_ARMED", "bool", 1);
             }
-            else if (SimVar.GetSimVarValue("L:AP_APP_ARMED", "bool") === 1 
+            else if (SimVar.GetSimVarValue("L:AP_APP_ARMED", "bool") === 1
             && this._navModeSelector.currentVerticalActiveState !== VerticalNavModeState.GP
             && this._navModeSelector.currentVerticalActiveState !== VerticalNavModeState.GS) {
                 SimVar.SetSimVarValue("L:AP_APP_ARMED", "bool", 0);
@@ -231,7 +231,7 @@ class Boeing_FMC extends FMCMainDisplay {
                 if (mcpAlt !== Math.round(altitude/100) * 100) {
                     this._navModeSelector.onNavChangedEvent('ALT_INT_PRESSED');
                 }
-            }      
+            }
         }
         else if (_event.indexOf("AP_ALT_HOLD") != -1) {
             this._navModeSelector.onNavChangedEvent('ALT_HOLD_PRESSED');

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/B747_8/FMC/Boeing_FMC.js
@@ -26,7 +26,7 @@ class Boeing_FMC extends FMCMainDisplay {
     Init() {
         super.Init();
         this.maxCruiseFL = 450;
-        this.cruiseFlightLevel = 100;
+        this.cruiseFlightLevel = null;
         this.onExec = () => {
             if (this.onExecPage) {
                 console.log("if this.onExecPage");
@@ -144,15 +144,20 @@ class Boeing_FMC extends FMCMainDisplay {
             let altitude = Simplane.getAltitudeAboveGround();
             if (altitude < 400) {
                 this._pendingVNAVActivation = true;
-                if (SimVar.GetSimVarValue("L:AP_VNAV_ARMED", "number") === 0) {
+                if (SimVar.GetSimVarValue("L:AP_VNAV_ARMED", "number") === 0 && !this.cruiseFlightLevel) {
+                    this.showErrorMessage("PERF/VNAV UNAVAILABLE");
+                } else if (SimVar.GetSimVarValue("L:AP_VNAV_ARMED", "number") === 0 && this.cruiseFlightLevel) {
                     SimVar.SetSimVarValue("L:AP_VNAV_ARMED", "number", 1);
-                }
-                else {
+                } else {
                     SimVar.SetSimVarValue("L:AP_VNAV_ARMED", "number", 0);
                 }
             }
             else {
-                this._navModeSelector.onNavChangedEvent('VNAV_PRESSED');
+                if (this.cruiseFlightLevel) {
+                    this._navModeSelector.onNavChangedEvent('VNAV_PRESSED');
+                } else {
+                    this.showErrorMessage("PERF/VNAV UNAVAILABLE");
+                }
             }
         }
         else if (_event.indexOf("AP_FLCH") != -1) {


### PR DESCRIPTION
**Changes:**
VNAV will not be inhibited when there is no CRZ ALT entered in the PERF INIT page.
Fix ETA in Pos Report to not show UNDEFINED anymore. (Temporary fix until POS REPORT gets reworked)

**Testing instructions:**
Load up aircraft, do not enter a CRZ ALT, check if VNAV does not activate.
Check POS REPORT page, see if ETA shows UTC time instead of UNDEFINED.