### PR TITLE
Airspeed Low Caution

### DIFF
--- a/salty-747/SimObjects/Airplanes/Salty_B747_8i/panel/panel.xml
+++ b/salty-747/SimObjects/Airplanes/Salty_B747_8i/panel/panel.xml
@@ -233,6 +233,17 @@
 
 		<Annunciation>
 		  <Type>Caution</Type>
+		  <Text>AIRSPEED LOW</Text>
+		  <Condition>
+			<LowerEqual>
+			  <Simvar name="AIRSPEED INDICATED" unit="knots"/>
+			  <Simvar name="L:74S_FMC_MIN_MANUEVER_SPEED" unit="knots"/>		  
+			</LowerEqual>
+		  </Condition>
+		</Annunciation>
+
+		<Annunciation>
+		  <Type>Caution</Type>
 		  <Text>ENG 1 SHUTDOWN</Text>
 		  <Condition>
 			<Equal>

--- a/salty-747/SimObjects/Airplanes/Salty_B747_8i/panel/panel.xml
+++ b/salty-747/SimObjects/Airplanes/Salty_B747_8i/panel/panel.xml
@@ -235,10 +235,16 @@
 		  <Type>Caution</Type>
 		  <Text>AIRSPEED LOW</Text>
 		  <Condition>
-			<LowerEqual>
-			  <Simvar name="AIRSPEED INDICATED" unit="knots"/>
-			  <Simvar name="L:74S_FMC_MIN_MANUEVER_SPEED" unit="knots"/>		  
-			</LowerEqual>
+		  	<And>
+				<LowerEqual>
+			  		<Simvar name="AIRSPEED INDICATED" unit="knots"/>
+			  		<Simvar name="L:74S_FMC_MIN_MANUEVER_SPEED" unit="knots"/>		  
+				</LowerEqual>
+				<GreaterEqual>
+					<Simvar name="PLANE ALT ABOVE GROUND MINUS CG" unit="feet"/>
+					<Constant>55</Constant>
+			  	</GreaterEqual>
+			</And>
 		  </Condition>
 		</Annunciation>
 

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/Salty_B747_8/PFD/AirspeedIndicator.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/Salty_B747_8/PFD/AirspeedIndicator.js
@@ -565,7 +565,7 @@ class Jet_PFD_AirspeedIndicator extends HTMLElement {
         
         /* Provides Low Airspeed Warning for PFD and EICAS */
         SimVar.SetSimVarValue("L:74S_FMC_MIN_MANUEVER_SPEED", "knots", stallProtectionMin);
-        if (indicatedSpeed <= stallProtectionMin) {
+        if (indicatedSpeed <= stallProtectionMin && !Simplane.getIsGrounded()) {
             this.cursorSVGShape.setAttribute("stroke", "orange");
             this.cursorSVGShape.setAttribute("stroke-width", "6");
         } 

--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/Salty_B747_8/PFD/AirspeedIndicator.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/Salty_B747_8/PFD/AirspeedIndicator.js
@@ -562,6 +562,18 @@ class Jet_PFD_AirspeedIndicator extends HTMLElement {
         let stallSpeed1G = this.getStallSpeed1G();
         let stallSpeed = stallSpeed1G * Math.sqrt(gLoad);
         let stallProtectionMin = Math.round(stallSpeed1G * Math.sqrt(1.3));
+        
+        /* Provides Low Airspeed Warning for PFD and EICAS */
+        SimVar.SetSimVarValue("L:74S_FMC_MIN_MANUEVER_SPEED", "knots", stallProtectionMin);
+        if (indicatedSpeed <= stallProtectionMin) {
+            this.cursorSVGShape.setAttribute("stroke", "orange");
+            this.cursorSVGShape.setAttribute("stroke-width", "6");
+        } 
+        else {
+            this.cursorSVGShape.setAttribute("stroke", "white");
+            this.cursorSVGShape.setAttribute("stroke-width", "3");
+        }
+
         let altitudeAboveGround = Simplane.getAltitudeAboveGround();
         this.smoothSpeeds(indicatedSpeed, dTime, maxSpeed, lowestSelectableSpeed, stallProtectionMin, stallProtectionMax, stallSpeed);
         this.updateSpeedTrendArrow(indicatedSpeed, speedTrend);


### PR DESCRIPTION
Added AIRSPEED LOW caution message to EICAS.

![image](https://user-images.githubusercontent.com/71572892/172902161-c74aa2ea-ef65-4e10-85dd-b9fc60970c30.png)


Triggers when airspeed drops below min manuever band shown on PFD.

Effects: AIRSPEED LOW message shows on EICAS along with Caution tone. Airspeed indicator on PFD is highlighted in amber.

**Instructions for testing:**

**Accelerate and decelerate into the amber band speed and check warning triggers and blanks appropriately.**

**Confirm that above mentioned behaviours all occur.**

**Confirm that the message does not trigger when on the ground, during rotation or during the landing flare (It is at very low** **altitude to avoid nuisance warnings.)**

