### PR TITLE
fix: simbrief uplink bugs

### DIFF
--- a/src/modules/src/fpm/cj4/fmc/CJ4_FMC_PilotWaypointParser.ts
+++ b/src/modules/src/fpm/cj4/fmc/CJ4_FMC_PilotWaypointParser.ts
@@ -132,7 +132,7 @@ export class CJ4_FMC_PilotWaypointParser {
     const longitude = matchFullLatLong[4] == "W" ? 0 - parseInt(matchFullLatLong[5]) - (parseFloat(matchFullLatLong[6]) / 60)
       : parseInt(matchFullLatLong[5]) + (parseFloat(matchFullLatLong[6]) / 60);
     const coordinates = new LatLongAlt(latitude, longitude, 0);
-    const ident = CJ4_FMC_PilotWaypointParser.procMatch(matchFullLatLong[7], matchFullLatLong[1] + matchFullLatLong[2].slice(0, 2) + matchFullLatLong[4] + matchFullLatLong[5] + matchFullLatLong[6].slice(0, 2));
+    const ident = CJ4_FMC_PilotWaypointParser.procMatch(matchFullLatLong[7], matchFullLatLong[1] + matchFullLatLong[2].slice(0, 2) + matchFullLatLong[4] + matchFullLatLong[5]);
 
     return WaypointBuilder.fromCoordinates(ident, coordinates, fmc);
   }


### PR DESCRIPTION
Fixes #467 

* Fixed coordinates inserting at the wrong index
* The exit waypoint of an airway is now inserted as direct if airway is not found
* Added support for SimBrief's less common 11-character coordinate format ("6000N12830W")

**Instructions for testing**
* Test SimBrief uplink with the route `OMDB`-`KSEA`, make sure you get a route similar to this one with the long form coordinates: ![uplink](https://user-images.githubusercontent.com/26278705/189532560-7c8fe8c8-f3ee-4971-ba45-1f2c1823ad59.png). 
* Test other routes as well (note that depending on your airac cycle and other things, getting `PARTIAL ROUTE 1 UPLINK` may be normal).