### PR TITLE
feat: automatic fuel management option

### DIFF
--- a/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/Salty_B747_8/FMC/OPTIONS/B747_8_FMC_Misc.js
+++ b/salty-747/html_ui/Pages/VCockpit/Instruments/Airliners/Salty_B747_8/FMC/OPTIONS/B747_8_FMC_Misc.js
@@ -26,6 +26,9 @@ class FMCSaltyOptions_Misc {
         const pauseAtTd = WTDataStore.get("PAUSE_AT_TD", 0);
         const pauseAtTdDisplayOption = pauseAtTd >= 1 ? onGreen : offGreen;
 
+        const autoFuel = WTDataStore.get("AUTO_FUEL", 0);
+        const autoFuelDisplayOption = autoFuel >= 1 ? onGreen : offGreen;
+
         fmc.setTemplate([
             ["MISC OPTIONS"],
             ["", "", "PILOTS VISIBILITY"],
@@ -34,12 +37,12 @@ class FMCSaltyOptions_Misc {
             [`< ${fpSyncDisplayOption}`, "", ""],
             ["", "", "PAUSE AT T/D"],
             [`< ${pauseAtTdDisplayOption}`, `${pauseAtTd >= 1 ? "UNPAUSE>" : ""}`],
-            ["", ""],
-            ["", ""],
+            ["", "", "AUTOMATIC FUEL MANAGEMENT"],
+            [`< ${autoFuelDisplayOption}`, ""],
             ["", ""],
             ["", ""],
             ["\xa0RETURN TO", ""],
-            ["<OPTIONS", ""]
+            ["<OPTIONS", ""],
         ]);
 
         /* LSK1 */
@@ -80,6 +83,11 @@ class FMCSaltyOptions_Misc {
 
         fmc.onLeftInput[2] = () => {
             WTDataStore.set("PAUSE_AT_TD", pauseAtTd >= 1 ? 0 : 1);
+            FMCSaltyOptions_Misc.ShowPage(fmc);
+        };
+
+        fmc.onLeftInput[3] = () => {
+            WTDataStore.set("AUTO_FUEL", autoFuel >= 1 ? 0 : 1);
             FMCSaltyOptions_Misc.ShowPage(fmc);
         };
 

--- a/src/modules/src/modules.ts
+++ b/src/modules/src/modules.ts
@@ -1,12 +1,13 @@
 import { Module } from "./module";
 import { SoundManager } from "./sound/soundmanager";
 import { PauseAtTD } from "./qol/PauseAtTD";
+import { AutoFuel } from "./qol/AutoFuel";
 
 export class SaltyModules implements Module {
     private modules: Module[];
 
     constructor() {
-        this.modules = [new SoundManager(), new PauseAtTD()];
+        this.modules = [new SoundManager(), new PauseAtTD(), new AutoFuel()];
     }
 
     public update(dt: number) {

--- a/src/modules/src/qol/AutoFuel.ts
+++ b/src/modules/src/qol/AutoFuel.ts
@@ -8,9 +8,6 @@ export class AutoFuel implements Module {
         const enabled = WTDataStore.get("AUTO_FUEL", 0) >= 1;
         if (!enabled) return;
 
-        this.closePumpsAfterEmpty([15, 16], "FUEL TANK CENTER2 QUANTITY");
-        this.closePumpsAfterEmpty([1, 2], "FUEL TANK CENTER QUANTITY");
-
         const leftOutboardQuantity =
             SimVar.GetSimVarValue("FUEL TANK LEFT AUX QUANTITY", "gallon") + SimVar.GetSimVarValue("FUEL TANK LEFT TIP QUANTITY", "gallon");
         const leftInboardQuantity = SimVar.GetSimVarValue("FUEL TANK LEFT MAIN QUANTITY", "gallon");
@@ -20,6 +17,9 @@ export class AutoFuel implements Module {
         const rightInboardQuantity = SimVar.GetSimVarValue("FUEL TANK RIGHT MAIN QUANTITY", "gallon");
 
         const tanksBalanced = leftInboardQuantity <= leftOutboardQuantity || rightInboardQuantity <= rightOutboardQuantity;
+
+        this.closePumpsAfterEmpty([15, 16], "FUEL TANK CENTER2 QUANTITY");
+        this.closePumpsAfterEmpty([1, 2], "FUEL TANK CENTER QUANTITY");
 
         // Switch off OVRD/JETTISON pumps 2 & 3 and close crossfeed valves 1 & 4 when outboard + reserve tanks and inboard tanks balanced
         this.ovrdPumps.forEach((pump) => SimVar.SetSimVarValue(`K:FUELSYSTEM_PUMP_${tanksBalanced ? "OFF" : "ON"}`, "number", pump));

--- a/src/modules/src/qol/AutoFuel.ts
+++ b/src/modules/src/qol/AutoFuel.ts
@@ -1,0 +1,43 @@
+import { Module } from "../module";
+
+export class AutoFuel implements Module {
+    private ovrdPumps = [7, 8, 11, 12];
+    private xfeedValves = [1, 4];
+
+    public update(_dt: number) {
+        this.closePumpsAfterEmpty([15, 16], "FUEL TANK CENTER2 QUANTITY");
+        this.closePumpsAfterEmpty([1, 2], "FUEL TANK CENTER QUANTITY");
+
+        const leftOutboardQuantity =
+            SimVar.GetSimVarValue("FUEL TANK LEFT AUX QUANTITY", "gallon") + SimVar.GetSimVarValue("FUEL TANK LEFT TIP QUANTITY", "gallon");
+        const leftInboardQuantity = SimVar.GetSimVarValue("FUEL TANK LEFT MAIN QUANTITY", "gallon");
+
+        const rightOutboardQuantity =
+            SimVar.GetSimVarValue("FUEL TANK RIGHT AUX QUANTITY", "gallon") + SimVar.GetSimVarValue("FUEL TANK RIGHT TIP QUANTITY", "gallon");
+        const rightInboardQuantity = SimVar.GetSimVarValue("FUEL TANK RIGHT MAIN QUANTITY", "gallon");
+
+        const tanksBalanced = leftInboardQuantity <= leftOutboardQuantity || rightInboardQuantity <= rightOutboardQuantity;
+
+        // Switch off OVRD/JETTISON pumps 2 & 3 and close crossfeed valves 1 & 4 when outboard + reserve tanks and inboard tanks balanced
+        this.ovrdPumps.forEach((pump) => SimVar.SetSimVarValue(`K:FUELSYSTEM_PUMP_${tanksBalanced ? "OFF" : "ON"}`, "number", pump));
+        this.xfeedValves.forEach((valve) => SimVar.SetSimVarValue(`K:FUELSYSTEM_VALVE_${tanksBalanced ? "CLOSE" : "OPEN"}`, "number", valve));
+    }
+
+    private closePumpsAfterEmpty(pumps: number[], quantityVar: string) {
+        const quantity = this.gallonsToPounds(SimVar.GetSimVarValue(quantityVar, "Gallons"));
+
+        for (const pump of pumps) {
+            const pumpActive = SimVar.GetSimVarValue(`FUELSYSTEM PUMP SWITCH:${pump}`, "bool");
+            if (quantity > 0 && !pumpActive) {
+                SimVar.SetSimVarValue("K:FUELSYSTEM_PUMP_ON", "number", pump);
+            } else if (quantity === 0 && pumpActive) {
+                SimVar.SetSimVarValue("K:FUELSYSTEM_PUMP_OFF", "number", pump);
+            }
+        }
+    }
+
+    private gallonsToPounds(gallons: number): number {
+        const fuelWeightPerGallon = SimVar.GetSimVarValue("FUEL WEIGHT PER GALLON", "lbs");
+        return gallons / fuelWeightPerGallon;
+    }
+}

--- a/src/modules/src/qol/AutoFuel.ts
+++ b/src/modules/src/qol/AutoFuel.ts
@@ -27,7 +27,7 @@ export class AutoFuel implements Module {
     }
 
     private closePumpsAfterEmpty(pumps: number[], quantityVar: string) {
-        const quantity = this.gallonsToPounds(SimVar.GetSimVarValue(quantityVar, "Gallons"));
+        const quantity = SimVar.GetSimVarValue(quantityVar, "Gallons");
 
         for (const pump of pumps) {
             const pumpActive = SimVar.GetSimVarValue(`FUELSYSTEM PUMP SWITCH:${pump}`, "bool");
@@ -37,10 +37,5 @@ export class AutoFuel implements Module {
                 SimVar.SetSimVarValue("K:FUELSYSTEM_PUMP_OFF", "number", pump);
             }
         }
-    }
-
-    private gallonsToPounds(gallons: number): number {
-        const fuelWeightPerGallon = SimVar.GetSimVarValue("FUEL WEIGHT PER GALLON", "lbs");
-        return gallons / fuelWeightPerGallon;
     }
 }

--- a/src/modules/src/qol/AutoFuel.ts
+++ b/src/modules/src/qol/AutoFuel.ts
@@ -5,6 +5,9 @@ export class AutoFuel implements Module {
     private xfeedValves = [1, 4];
 
     public update(_dt: number) {
+        const enabled = WTDataStore.get("AUTO_FUEL", 0) >= 1;
+        if (!enabled) return;
+
         this.closePumpsAfterEmpty([15, 16], "FUEL TANK CENTER2 QUANTITY");
         this.closePumpsAfterEmpty([1, 2], "FUEL TANK CENTER QUANTITY");
 


### PR DESCRIPTION
* Adds an option in the CDU to enable automatic fuel management. This will automatically do all the interventions normally required to be done manually.

**Instructions for testing**
* Enable the option in salty options -> misc
* Do a full flight, make sure it is long enough so that you'd normally need to do all the steps in our fuel guide (alternatively you could test using the salty fueling menu as well)
* Make sure that:
  * The stab pumps switch on when there is fuel inside the tanks and close when there is not
  * The center pumps switch on when there is fuel inside the tanks and close when there is not
  * When the outboard and inboard tanks are balanced (refer to our fuel guide), make sure that the OVRD/JETTISON pumps 2 & 3 switch off and crossfeed valves 1 & 4 close. You would normally get the FUEL TANK/ENG EICAS message at this stage
  * Everything works as in the fuel guide, without any interventions