### PR TITLE
fix: re-enabled inboard spoilers

### DIFF
--- a/salty-747/SimObjects/Airplanes/Salty_B747_8i-livery/MODEL.SALTY/747_8I.xml
+++ b/salty-747/SimObjects/Airplanes/Salty_B747_8i-livery/MODEL.SALTY/747_8I.xml
@@ -217,7 +217,6 @@
 				<TYPE>SPEEDBRAKES_AND_GROUND</TYPE>
 				<ANIM_NAME_LEFT>l_spoiler_key</ANIM_NAME_LEFT>
 				<ANIM_NAME_RIGHT>r_spoiler_key</ANIM_NAME_RIGHT>
-				<MAX_VALUE>45</MAX_VALUE>
 			</UseTemplate>
 			<UseTemplate Name="ASOBO_HANDLING_Flaps_Template">
 				<ANIM_NAME_LEFT>l_flap_percent_key</ANIM_NAME_LEFT>

--- a/salty-747/SimObjects/Airplanes/Salty_B747_8i/model/747_8I.xml
+++ b/salty-747/SimObjects/Airplanes/Salty_B747_8i/model/747_8I.xml
@@ -161,7 +161,6 @@
 				<TYPE>SPEEDBRAKES_AND_GROUND</TYPE>
 				<ANIM_NAME_LEFT>l_spoiler_key</ANIM_NAME_LEFT>
 				<ANIM_NAME_RIGHT>r_spoiler_key</ANIM_NAME_RIGHT>
-				<MAX_VALUE>45</MAX_VALUE>
 			</UseTemplate>
 			<UseTemplate Name="ASOBO_HANDLING_Flaps_Template">
 				<ANIM_NAME_LEFT>l_flap_percent_key</ANIM_NAME_LEFT>


### PR DESCRIPTION
Removed <MAX_VALUE>45</MAX_VALUE> from both model.xml's to allow the inboard spoilers to deploy properly. 

**INSTRUCTIONS TO TEST**

Load into base livery
Engage spoilers and verify both outboard and inboard spoilers deploy
Repeat above step with the Salty livery